### PR TITLE
refactor(pipelines): extract inline SQL into infrastructure/queries

### DIFF
--- a/src/pipelines/application/runners/loaders/loader_bronze_fred.py
+++ b/src/pipelines/application/runners/loaders/loader_bronze_fred.py
@@ -2,14 +2,18 @@ import os
 import uuid
 import json
 from datetime import datetime
+from pathlib import Path
 from dotenv import load_dotenv
 
 from ....application.policies import FullLoader
 from shared.database.client import SQLModelClient
+from shared.database.query_loader import load_query
 
 load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")
+
+_QUERIES_DIR = Path(__file__).parent.parent.parent.parent / "infrastructure" / "queries"
 
 
 class FullLoaderPostgresFred(FullLoader):
@@ -19,11 +23,10 @@ class FullLoaderPostgresFred(FullLoader):
         self._client = SQLModelClient(DATABASE_URL)
 
     def _create_partition(self):
-        sql = f"""
-            CREATE TABLE IF NOT EXISTS {self._partition_name}
-            PARTITION OF {self._table_name}
-            FOR VALUES FROM (:day) TO (:next_day);
-        """
+        sql = load_query(_QUERIES_DIR / "bronze" / "create_partition.sql").format(
+            partition_name=self._partition_name,
+            table_name=self._table_name,
+        )
         with self._client as client:
             client.execute(sql, {"day": self._day, "next_day": self._next_day})
 
@@ -33,22 +36,9 @@ class FullLoaderPostgresFred(FullLoader):
         Inserts one row per series per run.
         """
         ingested_date = datetime.now().date()
-        sql = f"""
-            INSERT INTO {self._table_name} (
-                id,
-                series_id,
-                ingested_date,
-                observation_start,
-                observations
-            )
-            VALUES (
-                :id,
-                :series_id,
-                :ingested_date,
-                :observation_start,
-                :observations
-            )
-        """
+        sql = load_query(_QUERIES_DIR / "bronze" / "fred_observations_insert.sql").format(
+            table_name=self._table_name
+        )
         with self._client as client:
             for record in data:
                 params = {

--- a/src/pipelines/application/runners/loaders/loader_bronze_t212.py
+++ b/src/pipelines/application/runners/loaders/loader_bronze_t212.py
@@ -2,16 +2,20 @@ import os
 import uuid
 import json
 from datetime import datetime
+from pathlib import Path
 from dotenv import load_dotenv
 from sqlalchemy import text
 
 from ....application.policies import FullLoader
 
 from shared.database.client import SQLModelClient
+from shared.database.query_loader import load_query
 
 load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")
+
+_QUERIES_DIR = Path(__file__).parent.parent.parent.parent / "infrastructure" / "queries"
 
 # Partition by date
 # Create exposition abstraction - view
@@ -27,16 +31,9 @@ class FullLoaderPostgresT212(FullLoader):
 
     def _loader(self, data: list[dict]):
         ingested_time = datetime.now().date()
-        # for record in data:
-        sql = f"""
-      INSERT INTO {self._table_name} (
-          id
-        , ingested_date
-        , account_data
-        , position_data
-      )
-      VALUES ((:id), (:ingested_date), (:account_data), (:position_data))
-    """
+        sql = load_query(_QUERIES_DIR / "bronze" / "t212_snapshot_insert.sql").format(
+            table_name=self._table_name
+        )
 
         params = {
             "id": str(uuid.uuid4()),
@@ -49,11 +46,10 @@ class FullLoaderPostgresT212(FullLoader):
             client.execute(sql, params=params)
 
     def _create_partition(self):
-        sql = f"""
-      CREATE TABLE IF NOT EXISTS {self._partition_name}
-      PARTITION OF {self._table_name}
-      FOR VALUES FROM (:day) TO (:next_day);
-    """
+        sql = load_query(_QUERIES_DIR / "bronze" / "create_partition.sql").format(
+            partition_name=self._partition_name,
+            table_name=self._table_name,
+        )
 
         with self._client as client:
             client.execute(sql, {"day": self._day, "next_day": self._next_day})
@@ -62,65 +58,15 @@ class FullLoaderPostgresT212(FullLoader):
 
     def _exposition_abstraction(self):
         drop_account = "DROP VIEW IF EXISTS raw.v_bronze_account"
-        create_account = f"""
-      CREATE VIEW raw.v_bronze_account AS
-      WITH cte AS (
-          SELECT
-              account_data->>'id'                                    AS external_id,
-              account_data->'cash'->>'inPies'                        AS cash_in_pies,
-              account_data->'cash'->>'availableToTrade'              AS cash_available_to_trade,
-              account_data->'cash'->>'reservedForOrders'             AS cash_reserved_for_orders,
-              account_data->>'currency'                              AS currency,
-              (account_data->>'totalValue')::NUMERIC                 AS total_value,
-              account_data->'investments'->>'totalCost'              AS investments_total_cost,
-              account_data->'investments'->>'realizedProfitLoss'     AS investments_realized_pnl,
-              account_data->'investments'->>'unrealizedProfitLoss'   AS investments_unrealized_pnl,
-              ingested_date,
-              ingested_timestamp
-          FROM {self._table_name}
-      )
-      SELECT
-          *,
-          external_id || '_' || currency || '_' || ingested_timestamp AS business_key
-      FROM cte
-    """
+        create_account = load_query(_QUERIES_DIR / "bronze" / "v_bronze_account.sql").format(
+            table_name=self._table_name
+        )
 
         drop_position = "DROP VIEW IF EXISTS raw.v_bronze_position"
-        create_position = f"""
-      CREATE OR REPLACE VIEW raw.v_bronze_position AS
-      WITH cte AS (
-          SELECT
-              t.id                                                           AS snapshot_id,
-              t.ingested_date,
-              t.ingested_timestamp,
-              pos->'instrument'->>'ticker'                                   AS ticker,
-              pos->'instrument'->>'name'                                     AS instrument_name,
-              pos->'instrument'->>'isin'                                     AS isin,
-              pos->'instrument'->>'currency'                                 AS instrument_currency,
-              (pos->>'createdAt')::TIMESTAMP                                 AS created_at,
-              (pos->>'quantity')::NUMERIC                                    AS quantity,
-              (pos->>'quantityAvailableForTrading')::NUMERIC                 AS quantity_available,
-              (pos->>'quantityInPies')::NUMERIC                              AS quantity_in_pies,
-              (pos->>'currentPrice')::NUMERIC                                AS current_price,
-              (pos->>'averagePricePaid')::NUMERIC                            AS average_price_paid,
-              pos->'walletImpact'->>'currency'                               AS wallet_currency,
-              (pos->'walletImpact'->>'totalCost')::NUMERIC                   AS total_cost,
-              (pos->'walletImpact'->>'currentValue')::NUMERIC                AS current_value,
-              (pos->'walletImpact'->>'unrealizedProfitLoss')::NUMERIC        AS unrealized_pnl,
-              (pos->'walletImpact'->>'fxImpact')::NUMERIC                    AS fx_impact
-          FROM {self._table_name} t,
-               jsonb_array_elements(
-                   CASE WHEN jsonb_typeof(t.position_data) = 'array'
-                        THEN t.position_data
-                        ELSE '[]'::jsonb
-                   END
-               ) AS pos
-      )
-      SELECT
-          *,
-          snapshot_id || '_' || ticker || '_' || ingested_timestamp AS business_key
-      FROM cte
-    """
+        create_position = load_query(_QUERIES_DIR / "bronze" / "v_bronze_position.sql").format(
+            table_name=self._table_name
+        )
+
         with self._client.engine.connect() as conn:
             conn.execute(text(drop_account))
             conn.execute(text(create_account))

--- a/src/pipelines/application/runners/pipeline_asset_portfolio.py
+++ b/src/pipelines/application/runners/pipeline_asset_portfolio.py
@@ -9,8 +9,10 @@ Source -> Destination (no transformation)
 import os
 import logging
 from dataclasses import dataclass, asdict
+from pathlib import Path
 from dotenv import load_dotenv
 from shared.database.client import SQLModelClient
+from shared.database.query_loader import load_query
 
 from ...application.protocols import Source, Destination
 from ...application.policies import Pipeline
@@ -26,6 +28,8 @@ load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 
+_QUERIES_DIR = Path(__file__).parent.parent.parent / "infrastructure" / "queries"
+
 
 @dataclass
 class Asset:
@@ -36,25 +40,19 @@ class Asset:
 
 
 class AssetPortfolioSource(Source):
+    def __init__(self):
+        self._sql = load_query(_QUERIES_DIR / "portfolio" / "asset_portfolio_source.sql")
+
     def extract(self) -> list:
-        sql = """
-      SELECT ticker, name, broker, currency
-      FROM (
-          SELECT *,
-                ROW_NUMBER() OVER (
-                    PARTITION BY ticker, broker, currency
-                    ORDER BY data_timestamp DESC
-                ) as rn
-          FROM staging.asset
-      ) t
-      WHERE rn = 1;
-    """
         with SQLModelClient(DATABASE_URL) as client:
-            res = client.execute(sql)
+            res = client.execute(self._sql)
             return res.fetchall()
 
 
 class AssetPortfolioDestination(Destination):
+    def __init__(self):
+        self._template = load_query(_QUERIES_DIR / "portfolio" / "asset_portfolio_upsert.sql")
+
     def load(self, data: list[dict]) -> None:
         # INSERTION POLICY: IDEMPOTENT
         merge_value_mapping = ",".join([f"""(
@@ -65,29 +63,10 @@ class AssetPortfolioDestination(Destination):
           )
         """ for r in data])
 
-        destination_table_name = "portfolio.asset"
-        asset_upsert_sql = f"""
-      MERGE INTO {destination_table_name} AS tgt
-      USING
-        (
-          VALUES
-            {merge_value_mapping}
+        asset_upsert_sql = self._template.format(
+            destination_table_name="portfolio.asset",
+            values=merge_value_mapping,
         )
-      AS src (ticker, name, broker, currency)
-      ON    tgt.ticker = src.ticker
-        AND tgt.broker = src.broker
-        AND tgt.currency = src.currency
-      WHEN NOT MATCHED THEN
-        INSERT (ticker, name, broker, currency)
-        VALUES (src.ticker, src.name, src.broker, src.currency)
-      WHEN MATCHED AND tgt.name <> src.name THEN
-      UPDATE
-        SET   name = src.name
-            , updated_timestamp = NOW()
-      WHEN NOT MATCHED BY SOURCE THEN
-        UPDATE
-          SET to_timestamp = NOW();
-    """
 
         with SQLModelClient(DATABASE_URL) as client:
             client.execute(asset_upsert_sql)

--- a/src/pipelines/application/runners/pipeline_bronze_fred.py
+++ b/src/pipelines/application/runners/pipeline_bronze_fred.py
@@ -8,6 +8,7 @@ raw observations in raw.fred_observations (JSONB, date-partitioned).
 import os
 import logging
 from datetime import date, timedelta
+from pathlib import Path
 from typing import Any
 from dotenv import load_dotenv
 from pydantic import ValidationError
@@ -19,6 +20,9 @@ from ...infrastructure.api.api_client_fred import FredAPIClient
 from ...domain.schemas.bronze.fred_api import FredObservationsResponse
 
 from shared.database.client import SQLModelClient
+from shared.database.query_loader import load_query
+
+_QUERIES_DIR = Path(__file__).parent.parent.parent / "infrastructure" / "queries"
 
 logging.basicConfig(
     level=logging.INFO,
@@ -65,11 +69,7 @@ class FredBronzeSource(Source):
         return results
 
     def _get_observation_start(self, series_id: str) -> str:
-        sql = """
-            SELECT MAX(observation_date) AS max_date
-            FROM staging.fred_observation
-            WHERE series_id = :series_id
-        """
+        sql = load_query(_QUERIES_DIR / "silver" / "fred_observation_start.sql")
         with self._db_client as client:
             result = client.execute(sql, params={"series_id": series_id})
             row = result.fetchone()

--- a/src/pipelines/application/runners/pipeline_gold_t212.py
+++ b/src/pipelines/application/runners/pipeline_gold_t212.py
@@ -11,6 +11,7 @@ Account fact deduplicates to one row per (date_id, portfolio_id) before loading.
 
 import os
 import logging
+from pathlib import Path
 from dotenv import load_dotenv
 from typing import List, Dict
 
@@ -19,10 +20,13 @@ from ...application.protocols import Source, Destination, Transformation
 from ...application.validators.schema_validator import SchemaValidator
 
 from shared.database.client import SQLModelClient
+from shared.database.query_loader import load_query
 from ...infrastructure.repositories.repository_factory import RepositoryFactory
 from ...infrastructure.repositories.dead_letter_destination import DeadLetterDestination
 from ...domain.schemas.gold.asset_gold import AssetGoldRecord
 from ...domain.schemas.gold.account_gold import AccountGoldRecord
+
+_QUERIES_DIR = Path(__file__).parent.parent.parent / "infrastructure" / "queries"
 
 logging.basicConfig(
     level=logging.INFO,
@@ -63,356 +67,13 @@ class T212GoldSource(Source):
 
     def __init__(self):
         self._client = SQLModelClient(DATABASE_URL)
+        self._sql = load_query(_QUERIES_DIR / "gold" / "t212_gold_source.sql")
 
     def extract(self):
-        sql = f"""
-            WITH fred_rfr AS (
-                SELECT
-                    observation_date,
-                    value / 100.0 / 252.0                               AS daily_rfr
-                FROM staging.fred_observation
-                WHERE series_id = 'DTB3'
-            ),
-
-            fred_sp500 AS (
-                SELECT
-                    observation_date,
-                    (value - LAG(value) OVER (ORDER BY observation_date))
-                        / NULLIF(LAG(value) OVER (ORDER BY observation_date), 0)
-                                                                        AS sp500_daily_return
-                FROM staging.fred_observation
-                WHERE series_id = 'SP500'
-            ),
-
-            asset_daily AS (
-                SELECT
-                    id,
-                    ticker,
-                    snapshot_id,
-                    data_timestamp,
-                    value,
-                    cost,
-                    profit,
-                    price,
-                    avg_price,
-                    fx_impact,
-                    ROW_NUMBER() OVER (
-                        PARTITION BY ticker, data_timestamp::DATE
-                        ORDER BY data_timestamp DESC
-                    )                                                       AS rn
-                FROM staging.asset
-            ),
-
-            asset_base AS (
-                SELECT
-                    id,
-                    ticker,
-                    snapshot_id,
-                    data_timestamp,
-                    value,
-                    cost,
-                    profit,
-                    price,
-                    avg_price,
-                    fx_impact,
-                    (price - LAG(price) OVER (PARTITION BY ticker ORDER BY data_timestamp))
-                    / NULLIF(
-                        LAG(price) OVER (PARTITION BY ticker ORDER BY data_timestamp),
-                        0
-                    )                                                       AS daily_return
-                FROM asset_daily
-                WHERE rn = 1
-            ),
-
-            asset_base_with_fred AS (
-                SELECT
-                    ab.*,
-                    COALESCE(rfr.daily_rfr, 0)                          AS daily_rfr,
-                    sp.sp500_daily_return
-                FROM asset_base ab
-                LEFT JOIN fred_rfr rfr  ON rfr.observation_date = ab.data_timestamp::DATE
-                LEFT JOIN fred_sp500 sp ON sp.observation_date  = ab.data_timestamp::DATE
-            ),
-
-            asset_stats AS (
-                SELECT
-                    *,
-
-                    EXP(SUM(LN(1 + COALESCE(daily_return, 0))) OVER (
-                        PARTITION BY ticker
-                        ORDER BY data_timestamp
-                        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-                    )) - 1                                                  AS cumulative_return,
-
-                    AVG(value) OVER (
-                        PARTITION BY ticker ORDER BY data_timestamp
-                        ROWS BETWEEN 19 PRECEDING AND CURRENT ROW
-                    )                                                       AS value_ma_20d,
-                    AVG(value) OVER (
-                        PARTITION BY ticker ORDER BY data_timestamp
-                        ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
-                    )                                                       AS value_ma_30d,
-                    AVG(value) OVER (
-                        PARTITION BY ticker ORDER BY data_timestamp
-                        ROWS BETWEEN 49 PRECEDING AND CURRENT ROW
-                    )                                                       AS value_ma_50d,
-
-                    AVG(price) OVER (
-                        PARTITION BY ticker ORDER BY data_timestamp
-                        ROWS BETWEEN 19 PRECEDING AND CURRENT ROW
-                    )                                                       AS price_ma_20d,
-                    AVG(price) OVER (
-                        PARTITION BY ticker ORDER BY data_timestamp
-                        ROWS BETWEEN 49 PRECEDING AND CURRENT ROW
-                    )                                                       AS price_ma_50d,
-
-                    STDDEV(daily_return) OVER (
-                        PARTITION BY ticker ORDER BY data_timestamp
-                        ROWS BETWEEN 19 PRECEDING AND CURRENT ROW
-                    )                                                       AS volatility_20d,
-                    STDDEV(daily_return) OVER (
-                        PARTITION BY ticker ORDER BY data_timestamp
-                        ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
-                    )                                                       AS volatility_30d,
-                    STDDEV(daily_return) OVER (
-                        PARTITION BY ticker ORDER BY data_timestamp
-                        ROWS BETWEEN 49 PRECEDING AND CURRENT ROW
-                    )                                                       AS volatility_50d,
-
-                    MAX(value) OVER (
-                        PARTITION BY ticker ORDER BY data_timestamp
-                        ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
-                    )                                                       AS recent_value_high_30d,
-                    MIN(value) OVER (
-                        PARTITION BY ticker ORDER BY data_timestamp
-                        ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
-                    )                                                       AS recent_value_low_30d,
-                    MAX(profit) OVER (
-                        PARTITION BY ticker ORDER BY data_timestamp
-                        ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
-                    )                                                       AS recent_profit_high_30d,
-                    MIN(profit) OVER (
-                        PARTITION BY ticker ORDER BY data_timestamp
-                        ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
-                    )                                                       AS recent_profit_low_30d,
-
-                    MAX(value) OVER (PARTITION BY ticker)                   AS value_high_alltime,
-                    MIN(value) OVER (PARTITION BY ticker)                   AS value_low_alltime,
-
-                    COVAR_POP(daily_return, sp500_daily_return) OVER (
-                        PARTITION BY ticker ORDER BY data_timestamp
-                        ROWS BETWEEN 59 PRECEDING AND CURRENT ROW
-                    ) / NULLIF(
-                        VAR_POP(sp500_daily_return) OVER (
-                            PARTITION BY ticker ORDER BY data_timestamp
-                            ROWS BETWEEN 59 PRECEDING AND CURRENT ROW
-                        ), 0
-                    )                                                       AS beta_60d,
-
-                    AVG(daily_return - daily_rfr) OVER (
-                        PARTITION BY ticker ORDER BY data_timestamp
-                        ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
-                    ) / NULLIF(
-                        STDDEV_POP(daily_return) OVER (
-                            PARTITION BY ticker ORDER BY data_timestamp
-                            ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
-                        ), 0
-                    ) * SQRT(252)                                           AS sharpe_ratio_30d
-                FROM asset_base_with_fred
-            ),
-
-            asset_latest AS (
-                SELECT
-                    1                                                       AS rn,
-                    *
-                FROM asset_stats
-            ),
-
-            account_deduped AS (
-                SELECT
-                    *,
-                    ROW_NUMBER() OVER (
-                        PARTITION BY data_timestamp::DATE
-                        ORDER BY data_timestamp DESC
-                    )                                                       AS rn
-                FROM staging.account
-            ),
-
-            account_ranked AS (
-                SELECT
-                    *,
-                    LAG(total_value) OVER (
-                        ORDER BY data_timestamp
-                    )                                                       AS prev_total_value,
-                    LAG(investments_total_cost + investments_unrealized_pnl) OVER (
-                        ORDER BY data_timestamp
-                    )                                                       AS prev_invested_value
-                FROM account_deduped
-                WHERE rn = 1
-            ),
-
-            account_with_fred AS (
-                SELECT
-                    ar.*,
-                    COALESCE(rfr.daily_rfr, 0)                          AS daily_rfr,
-                    COALESCE(sp.sp500_daily_return, 0)                  AS sp500_daily_return,
-                    ((ar.investments_total_cost + ar.investments_unrealized_pnl)
-                        - COALESCE(
-                            ar.prev_invested_value,
-                            ar.investments_total_cost + ar.investments_unrealized_pnl
-                        ))
-                        / NULLIF(ar.prev_invested_value, 0)             AS portfolio_daily_return
-                FROM account_ranked ar
-                LEFT JOIN fred_rfr rfr  ON rfr.observation_date = ar.data_timestamp::DATE
-                LEFT JOIN fred_sp500 sp ON sp.observation_date  = ar.data_timestamp::DATE
-            ),
-
-            portfolio_metrics AS (
-                SELECT
-                    snapshot_id,
-                    sp500_daily_return                                   AS benchmark_return_daily,
-
-                    AVG(portfolio_daily_return - daily_rfr) OVER (
-                        ORDER BY data_timestamp
-                        ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
-                    ) / NULLIF(
-                        STDDEV_POP(portfolio_daily_return) OVER (
-                            ORDER BY data_timestamp
-                            ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
-                        ), 0
-                    ) * SQRT(252)                                        AS sharpe_ratio_30d,
-
-                    (EXP(SUM(LN(1 + COALESCE(portfolio_daily_return, 0))) OVER (
-                        ORDER BY data_timestamp
-                        ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
-                    )) - 1)
-                    - (EXP(SUM(LN(1 + COALESCE(sp500_daily_return, 0))) OVER (
-                        ORDER BY data_timestamp
-                        ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
-                    )) - 1)                                              AS portfolio_vs_benchmark_30d
-                FROM account_with_fred
-            ),
-
-            portfolio_agg AS (
-                SELECT
-                    al.snapshot_id,
-                    SUM(al.fx_impact)                                       AS fx_impact_total,
-                    SUM(
-                        al.value / NULLIF(acc.investments_total_cost + acc.investments_unrealized_pnl, 0)
-                        * COALESCE(al.volatility_30d, 0)
-                    )                                                       AS portfolio_volatility_weighted,
-                    SUM(
-                        al.value / NULLIF(acc.investments_total_cost + acc.investments_unrealized_pnl, 0)
-                        * COALESCE(al.beta_60d, 0)
-                    )                                                       AS portfolio_beta_weighted
-                FROM asset_latest al
-                JOIN account_with_fred acc ON acc.snapshot_id = al.snapshot_id
-                WHERE al.rn = 1
-                GROUP BY al.snapshot_id
-            )
-
-            SELECT
-                TO_CHAR(a.data_timestamp, 'YYYYMMDD')::INTEGER              AS date_id,
-                dp.id                                                        AS portfolio_id,
-                da.asset_id,
-
-                -- fact_price
-                a.price,
-                a.avg_price,
-
-                -- fact_valuation
-                a.value,
-                a.cost                                                       AS cost_basis,
-                a.profit                                                     AS unrealized_pnl,
-                a.profit / NULLIF(a.cost, 0) * 100                          AS unrealized_pnl_pct,
-                NULL::FLOAT                                                  AS realized_pnl,
-                a.value / NULLIF(acc.investments_total_cost + acc.investments_unrealized_pnl, 0) * 100
-                                                                             AS position_weight_pct,
-                a.fx_impact,
-
-                -- fact_return
-                COALESCE(a.daily_return, 0)                                 AS daily_value_return,
-                COALESCE(a.cumulative_return, 0)                            AS cumulative_value_return,
-
-                -- fact_technical
-                (a.value - a.recent_value_high_30d)
-                    / NULLIF(a.recent_value_high_30d, 0)                    AS value_drawdown_pct_30d,
-                a.value_high_alltime,
-                a.value_low_alltime,
-                a.value_ma_20d,
-                a.value_ma_30d,
-                a.value_ma_50d,
-                a.price_ma_20d,
-                a.price_ma_50d,
-                a.volatility_20d,
-                a.volatility_30d,
-                a.volatility_50d,
-                COALESCE(a.volatility_30d, 0) * a.value * 1.65              AS var_95_1d,
-                COALESCE(a.recent_profit_high_30d, 0)
-                    - COALESCE(a.recent_profit_low_30d, 0)                  AS profit_range_30d,
-                a.recent_profit_high_30d,
-                a.recent_profit_low_30d,
-                a.recent_value_high_30d,
-                a.recent_value_low_30d,
-
-                -- fact_technical (FRED)
-                a.beta_60d,
-                a.sharpe_ratio_30d,
-
-                -- fact_signal
-                a.price / NULLIF(a.avg_price, 0)                            AS dca_bias,
-                a.value_ma_20d - a.value_ma_50d                             AS value_ma_crossover_signal,
-                (a.price > a.price_ma_20d)                                  AS price_above_ma_20d,
-                (a.price > a.price_ma_50d)                                  AS price_above_ma_50d,
-
-                -- fact_portfolio_daily (prefixed to avoid conflict with asset columns above)
-                acc.total_value                                              AS acct_total_value,
-                acc.investments_total_cost                                   AS acct_total_cost,
-                acc.investments_unrealized_pnl                               AS acct_unrealized_pnl,
-                acc.investments_unrealized_pnl
-                    / NULLIF(acc.investments_total_cost, 0) * 100           AS acct_unrealized_pnl_pct,
-                acc.investments_realized_pnl                                 AS acct_realized_pnl,
-                (acc.investments_total_cost + acc.investments_unrealized_pnl)
-                    - COALESCE(
-                        acc.prev_invested_value,
-                        acc.investments_total_cost + acc.investments_unrealized_pnl
-                    )                                                       AS daily_value_change_abs,
-                ((acc.investments_total_cost + acc.investments_unrealized_pnl)
-                    - COALESCE(
-                        acc.prev_invested_value,
-                        acc.investments_total_cost + acc.investments_unrealized_pnl
-                    ))
-                    / NULLIF(acc.prev_invested_value, 0) * 100              AS daily_value_change_pct,
-                acc.cash_available_to_trade                                  AS cash_available,
-                acc.cash_reserved_for_orders                                 AS cash_reserved,
-                acc.cash_in_pies,
-                (acc.total_value - acc.cash_available_to_trade)
-                    / NULLIF(acc.total_value, 0) * 100                      AS cash_deployment_ratio,
-                pa.fx_impact_total,
-                pa.portfolio_volatility_weighted,
-                pa.portfolio_beta_weighted,
-
-                -- fact_portfolio_daily (FRED)
-                pm.sharpe_ratio_30d                                      AS acct_sharpe_ratio_30d,
-                pm.benchmark_return_daily                                 AS acct_benchmark_return_daily,
-                pm.portfolio_vs_benchmark_30d                             AS acct_portfolio_vs_benchmark_30d
-
-            FROM asset_latest a
-            JOIN account_with_fred acc ON acc.snapshot_id = a.snapshot_id
-            JOIN analytics.dim_asset da
-                ON da.ticker = a.ticker
-            CROSS JOIN (
-                SELECT id
-                FROM analytics.dim_portfolio
-                WHERE portfolio_id = '{portfolio_id}'
-            ) dp
-            LEFT JOIN portfolio_agg pa ON pa.snapshot_id = a.snapshot_id
-            LEFT JOIN portfolio_metrics pm ON pm.snapshot_id = a.snapshot_id
-            WHERE a.rn = 1
-        """
         with self._client as db:
-            result = db.execute(sql)
+            result = db.execute(self._sql, params={"portfolio_id": str(portfolio_id)})
         return result.fetchall()
+
 
 
 # ---------------------------------------------------------------------------
@@ -674,28 +335,8 @@ class PipelineT212Gold(Pipeline):
 
     def _ensure_dimensions(self):
         with self._db as db:
-            db.execute("""
-                INSERT INTO analytics.dim_portfolio (portfolio_id, name, base_currency)
-                SELECT DISTINCT ON (external_id)
-                    external_id AS portfolio_id,
-                    broker      AS name,
-                    currency    AS base_currency
-                FROM staging.account
-                ORDER BY external_id, data_timestamp DESC
-                ON CONFLICT (portfolio_id) DO NOTHING
-            """)
-            db.execute("""
-                INSERT INTO analytics.dim_asset (asset_id, ticker, name, asset_type, currency)
-                SELECT DISTINCT ON (ticker)
-                    id          AS asset_id,
-                    ticker,
-                    name,
-                    'STOCK'     AS asset_type,
-                    currency
-                FROM staging.asset
-                ORDER BY ticker, data_timestamp DESC
-                ON CONFLICT (ticker) DO NOTHING
-            """)
+            db.execute(load_query(_QUERIES_DIR / "gold" / "dim_portfolio_seed.sql"))
+            db.execute(load_query(_QUERIES_DIR / "gold" / "dim_asset_seed.sql"))
 
 
 if __name__ == "__main__":

--- a/src/pipelines/application/runners/portfolio_enrichment_synchronizer.py
+++ b/src/pipelines/application/runners/portfolio_enrichment_synchronizer.py
@@ -1,11 +1,15 @@
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 from shared.database.client import SQLModelClient
+from shared.database.query_loader import load_query
 import logging
 
 load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")
+
+_QUERIES_DIR = Path(__file__).parent.parent.parent / "infrastructure" / "queries"
 
 logging.basicConfig(
     level=logging.INFO,
@@ -15,156 +19,32 @@ logging.basicConfig(
 )
 
 
-def sychronize_industry():
-    target = "staging.industry"
-    source = "portfolio.industry"
-    sql = f"""
-    UPDATE {target}
-    SET to_timestamp = CURRENT_DATE
-      , is_current = false
-    FROM {target} as tgt
-      INNER JOIN {source} src
-        ON tgt.industry_id = src.id
-    WHERE tgt.is_current = true
-      AND (
-          tgt.name <> src.name
-        OR
-          tgt.description <> src.description
-      );
-
-  INSERT INTO {target} (industry_id, name, description)
-  SELECT src.id, src.name, src.description
-  FROM {target} tgt
-    RIGHT JOIN {source} src
-      ON tgt.industry_id = src.id
-        AND tgt.is_current = true
-  WHERE tgt.industry_id IS NULL;
-  """
-
+def _run_sync(query_file: str, target: str, source: str) -> None:
+    sql = load_query(_QUERIES_DIR / "portfolio" / query_file).format(
+        target=target, source=source
+    )
     with SQLModelClient(database_url=DATABASE_URL) as client:
         client.execute(sql)
+
+
+def sychronize_industry():
+    _run_sync("sync_industry.sql", target="staging.industry", source="portfolio.industry")
 
 
 def sychronize_sector():
-    target = "staging.sector"
-    source = "portfolio.sector"
-    sql = f"""
-    UPDATE {target}
-    SET to_timestamp = CURRENT_DATE
-      , is_current = false
-    FROM {target} as tgt
-      INNER JOIN {source} src
-        ON tgt.sector_id = src.id
-    WHERE tgt.is_current = true
-      AND (
-          tgt.name <> src.name
-        OR
-          tgt.industry_id <> src.industry_id
-        OR
-          tgt.description <> src.description
-      );
-
-  INSERT INTO {target} (sector_id, industry_id, name, description)
-  SELECT src.id, src.industry_id, src.name, src.description
-  FROM {target} tgt
-    RIGHT JOIN {source} src
-      ON tgt.sector_id = src.id
-        AND tgt.is_current = true
-  WHERE tgt.sector_id IS NULL;
-  """
-
-    with SQLModelClient(database_url=DATABASE_URL) as client:
-        client.execute(sql)
+    _run_sync("sync_sector.sql", target="staging.sector", source="portfolio.sector")
 
 
 def sychronize_tag():
-    target = "staging.tag"
-    source = "portfolio.tag"
-    sql = f"""
-    UPDATE {target}
-    SET to_timestamp = CURRENT_DATE
-      , is_current = false
-    FROM {target} as tgt
-      INNER JOIN {source} src
-        ON tgt.tag_id = src.id
-    WHERE tgt.is_current = true
-      AND (
-          tgt.name <> src.name
-        OR
-          tgt.category_id <> src.category_id
-        OR
-          tgt.description <> src.description
-      );
-
-  INSERT INTO {target} (tag_id, name, description, category_id)
-  SELECT src.id, src.name, src.description, src.category_id
-  FROM {target} tgt
-    RIGHT JOIN {source} src
-      ON tgt.tag_id = src.id
-        AND tgt.is_current = true
-  WHERE tgt.tag_id IS NULL;
-  """
-
-    with SQLModelClient(database_url=DATABASE_URL) as client:
-        client.execute(sql)
+    _run_sync("sync_tag.sql", target="staging.tag", source="portfolio.tag")
 
 
 def sychronize_category():
-    target = "staging.category"
-    source = "portfolio.category"
-    sql = f"""
-    UPDATE {target}
-    SET to_timestamp = CURRENT_DATE
-      , is_current = false
-    FROM {target} as tgt
-      INNER JOIN {source} src
-        ON tgt.category_id = src.id
-    WHERE tgt.is_current = true
-      AND (
-          tgt.name <> src.name
-        OR
-          tgt.description <> src.description
-      );
-
-  INSERT INTO {target} (category_id, name, description)
-  SELECT src.id, src.name, src.description
-  FROM {target} tgt
-    RIGHT JOIN {source} src
-      ON tgt.category_id = src.id
-        AND tgt.is_current = true
-  WHERE tgt.category_id IS NULL;
-  """
-
-    with SQLModelClient(database_url=DATABASE_URL) as client:
-        client.execute(sql)
+    _run_sync("sync_category.sql", target="staging.category", source="portfolio.category")
 
 
 def sychronize_asset_tag():
-    target = "staging.asset_tag"
-    source = "portfolio.asset_tag"
-    sql = f"""
-    UPDATE {target}
-    SET to_timestamp = CURRENT_DATE
-      , is_current = false
-    FROM {target} as tgt
-        LEFT JOIN {source} src
-        ON tgt.asset_id = src.asset_id
-        AND tgt.tag_id = src.tag_id
-    WHERE tgt.is_current = true
-      AND tgt.id IS NULL;
-
-  INSERT INTO {target} (asset_id, tag_id)
-  SELECT src.asset_id, src.tag_id
-  FROM {target} tgt
-    RIGHT JOIN {source} src
-        ON tgt.asset_id = src.asset_id
-        AND tgt.tag_id = src.tag_id
-        AND tgt.is_current = true
-  WHERE tgt.tag_id IS NULL AND tgt.asset_id IS NULL;
-  """
-
-    with SQLModelClient(database_url=DATABASE_URL) as client:
-        client.execute(sql)
+    _run_sync("sync_asset_tag.sql", target="staging.asset_tag", source="portfolio.asset_tag")
 
 
 def enrichment_sychronization():

--- a/src/pipelines/infrastructure/queries/bronze/create_partition.sql
+++ b/src/pipelines/infrastructure/queries/bronze/create_partition.sql
@@ -1,0 +1,3 @@
+CREATE TABLE IF NOT EXISTS {partition_name}
+PARTITION OF {table_name}
+FOR VALUES FROM (:day) TO (:next_day);

--- a/src/pipelines/infrastructure/queries/bronze/fred_observations_insert.sql
+++ b/src/pipelines/infrastructure/queries/bronze/fred_observations_insert.sql
@@ -1,0 +1,14 @@
+INSERT INTO {table_name} (
+    id,
+    series_id,
+    ingested_date,
+    observation_start,
+    observations
+)
+VALUES (
+    :id,
+    :series_id,
+    :ingested_date,
+    :observation_start,
+    :observations
+)

--- a/src/pipelines/infrastructure/queries/bronze/t212_snapshot_insert.sql
+++ b/src/pipelines/infrastructure/queries/bronze/t212_snapshot_insert.sql
@@ -1,0 +1,7 @@
+INSERT INTO {table_name} (
+    id
+  , ingested_date
+  , account_data
+  , position_data
+)
+VALUES ((:id), (:ingested_date), (:account_data), (:position_data))

--- a/src/pipelines/infrastructure/queries/bronze/v_bronze_account.sql
+++ b/src/pipelines/infrastructure/queries/bronze/v_bronze_account.sql
@@ -1,0 +1,20 @@
+CREATE VIEW raw.v_bronze_account AS
+WITH cte AS (
+    SELECT
+        account_data->>'id'                                    AS external_id,
+        account_data->'cash'->>'inPies'                        AS cash_in_pies,
+        account_data->'cash'->>'availableToTrade'              AS cash_available_to_trade,
+        account_data->'cash'->>'reservedForOrders'             AS cash_reserved_for_orders,
+        account_data->>'currency'                              AS currency,
+        (account_data->>'totalValue')::NUMERIC                 AS total_value,
+        account_data->'investments'->>'totalCost'              AS investments_total_cost,
+        account_data->'investments'->>'realizedProfitLoss'     AS investments_realized_pnl,
+        account_data->'investments'->>'unrealizedProfitLoss'   AS investments_unrealized_pnl,
+        ingested_date,
+        ingested_timestamp
+    FROM {table_name}
+)
+SELECT
+    *,
+    external_id || '_' || currency || '_' || ingested_timestamp AS business_key
+FROM cte

--- a/src/pipelines/infrastructure/queries/bronze/v_bronze_position.sql
+++ b/src/pipelines/infrastructure/queries/bronze/v_bronze_position.sql
@@ -1,0 +1,33 @@
+CREATE OR REPLACE VIEW raw.v_bronze_position AS
+WITH cte AS (
+    SELECT
+        t.id                                                           AS snapshot_id,
+        t.ingested_date,
+        t.ingested_timestamp,
+        pos->'instrument'->>'ticker'                                   AS ticker,
+        pos->'instrument'->>'name'                                     AS instrument_name,
+        pos->'instrument'->>'isin'                                     AS isin,
+        pos->'instrument'->>'currency'                                 AS instrument_currency,
+        (pos->>'createdAt')::TIMESTAMP                                 AS created_at,
+        (pos->>'quantity')::NUMERIC                                    AS quantity,
+        (pos->>'quantityAvailableForTrading')::NUMERIC                 AS quantity_available,
+        (pos->>'quantityInPies')::NUMERIC                              AS quantity_in_pies,
+        (pos->>'currentPrice')::NUMERIC                                AS current_price,
+        (pos->>'averagePricePaid')::NUMERIC                            AS average_price_paid,
+        pos->'walletImpact'->>'currency'                               AS wallet_currency,
+        (pos->'walletImpact'->>'totalCost')::NUMERIC                   AS total_cost,
+        (pos->'walletImpact'->>'currentValue')::NUMERIC                AS current_value,
+        (pos->'walletImpact'->>'unrealizedProfitLoss')::NUMERIC        AS unrealized_pnl,
+        (pos->'walletImpact'->>'fxImpact')::NUMERIC                    AS fx_impact
+    FROM {table_name} t,
+         jsonb_array_elements(
+             CASE WHEN jsonb_typeof(t.position_data) = 'array'
+                  THEN t.position_data
+                  ELSE '[]'::jsonb
+             END
+         ) AS pos
+)
+SELECT
+    *,
+    snapshot_id || '_' || ticker || '_' || ingested_timestamp AS business_key
+FROM cte

--- a/src/pipelines/infrastructure/queries/gold/dim_asset_seed.sql
+++ b/src/pipelines/infrastructure/queries/gold/dim_asset_seed.sql
@@ -1,0 +1,10 @@
+INSERT INTO analytics.dim_asset (asset_id, ticker, name, asset_type, currency)
+SELECT DISTINCT ON (ticker)
+    id          AS asset_id,
+    ticker,
+    name,
+    'STOCK'     AS asset_type,
+    currency
+FROM staging.asset
+ORDER BY ticker, data_timestamp DESC
+ON CONFLICT (ticker) DO NOTHING

--- a/src/pipelines/infrastructure/queries/gold/dim_portfolio_seed.sql
+++ b/src/pipelines/infrastructure/queries/gold/dim_portfolio_seed.sql
@@ -1,0 +1,8 @@
+INSERT INTO analytics.dim_portfolio (portfolio_id, name, base_currency)
+SELECT DISTINCT ON (external_id)
+    external_id AS portfolio_id,
+    broker      AS name,
+    currency    AS base_currency
+FROM staging.account
+ORDER BY external_id, data_timestamp DESC
+ON CONFLICT (portfolio_id) DO NOTHING

--- a/src/pipelines/infrastructure/queries/gold/t212_gold_source.sql
+++ b/src/pipelines/infrastructure/queries/gold/t212_gold_source.sql
@@ -1,4 +1,22 @@
-WITH asset_daily AS (
+WITH fred_rfr AS (
+    SELECT
+        observation_date,
+        value / 100.0 / 252.0                               AS daily_rfr
+    FROM staging.fred_observation
+    WHERE series_id = 'DTB3'
+),
+
+fred_sp500 AS (
+    SELECT
+        observation_date,
+        (value - LAG(value) OVER (ORDER BY observation_date))
+            / NULLIF(LAG(value) OVER (ORDER BY observation_date), 0)
+                                                            AS sp500_daily_return
+    FROM staging.fred_observation
+    WHERE series_id = 'SP500'
+),
+
+asset_daily AS (
     SELECT
         id,
         ticker,
@@ -36,6 +54,16 @@ asset_base AS (
         )                                                       AS daily_return
     FROM asset_daily
     WHERE rn = 1
+),
+
+asset_base_with_fred AS (
+    SELECT
+        ab.*,
+        COALESCE(rfr.daily_rfr, 0)                          AS daily_rfr,
+        sp.sp500_daily_return
+    FROM asset_base ab
+    LEFT JOIN fred_rfr rfr  ON rfr.observation_date = ab.data_timestamp::DATE
+    LEFT JOIN fred_sp500 sp ON sp.observation_date  = ab.data_timestamp::DATE
 ),
 
 asset_stats AS (
@@ -101,8 +129,28 @@ asset_stats AS (
         )                                                       AS recent_profit_low_30d,
 
         MAX(value) OVER (PARTITION BY ticker)                   AS value_high_alltime,
-        MIN(value) OVER (PARTITION BY ticker)                   AS value_low_alltime
-    FROM asset_base
+        MIN(value) OVER (PARTITION BY ticker)                   AS value_low_alltime,
+
+        COVAR_POP(daily_return, sp500_daily_return) OVER (
+            PARTITION BY ticker ORDER BY data_timestamp
+            ROWS BETWEEN 59 PRECEDING AND CURRENT ROW
+        ) / NULLIF(
+            VAR_POP(sp500_daily_return) OVER (
+                PARTITION BY ticker ORDER BY data_timestamp
+                ROWS BETWEEN 59 PRECEDING AND CURRENT ROW
+            ), 0
+        )                                                       AS beta_60d,
+
+        AVG(daily_return - daily_rfr) OVER (
+            PARTITION BY ticker ORDER BY data_timestamp
+            ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
+        ) / NULLIF(
+            STDDEV_POP(daily_return) OVER (
+                PARTITION BY ticker ORDER BY data_timestamp
+                ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
+            ), 0
+        ) * SQRT(252)                                           AS sharpe_ratio_30d
+    FROM asset_base_with_fred
 ),
 
 asset_latest AS (
@@ -135,6 +183,48 @@ account_ranked AS (
     WHERE rn = 1
 ),
 
+account_with_fred AS (
+    SELECT
+        ar.*,
+        COALESCE(rfr.daily_rfr, 0)                          AS daily_rfr,
+        COALESCE(sp.sp500_daily_return, 0)                  AS sp500_daily_return,
+        ((ar.investments_total_cost + ar.investments_unrealized_pnl)
+            - COALESCE(
+                ar.prev_invested_value,
+                ar.investments_total_cost + ar.investments_unrealized_pnl
+            ))
+            / NULLIF(ar.prev_invested_value, 0)             AS portfolio_daily_return
+    FROM account_ranked ar
+    LEFT JOIN fred_rfr rfr  ON rfr.observation_date = ar.data_timestamp::DATE
+    LEFT JOIN fred_sp500 sp ON sp.observation_date  = ar.data_timestamp::DATE
+),
+
+portfolio_metrics AS (
+    SELECT
+        snapshot_id,
+        sp500_daily_return                                   AS benchmark_return_daily,
+
+        AVG(portfolio_daily_return - daily_rfr) OVER (
+            ORDER BY data_timestamp
+            ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
+        ) / NULLIF(
+            STDDEV_POP(portfolio_daily_return) OVER (
+                ORDER BY data_timestamp
+                ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
+            ), 0
+        ) * SQRT(252)                                        AS sharpe_ratio_30d,
+
+        (EXP(SUM(LN(1 + COALESCE(portfolio_daily_return, 0))) OVER (
+            ORDER BY data_timestamp
+            ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
+        )) - 1)
+        - (EXP(SUM(LN(1 + COALESCE(sp500_daily_return, 0))) OVER (
+            ORDER BY data_timestamp
+            ROWS BETWEEN 29 PRECEDING AND CURRENT ROW
+        )) - 1)                                              AS portfolio_vs_benchmark_30d
+    FROM account_with_fred
+),
+
 portfolio_agg AS (
     SELECT
         al.snapshot_id,
@@ -142,9 +232,13 @@ portfolio_agg AS (
         SUM(
             al.value / NULLIF(acc.investments_total_cost + acc.investments_unrealized_pnl, 0)
             * COALESCE(al.volatility_30d, 0)
-        )                                                       AS portfolio_volatility_weighted
+        )                                                       AS portfolio_volatility_weighted,
+        SUM(
+            al.value / NULLIF(acc.investments_total_cost + acc.investments_unrealized_pnl, 0)
+            * COALESCE(al.beta_60d, 0)
+        )                                                       AS portfolio_beta_weighted
     FROM asset_latest al
-    JOIN account_ranked acc ON acc.snapshot_id = al.snapshot_id
+    JOIN account_with_fred acc ON acc.snapshot_id = al.snapshot_id
     WHERE al.rn = 1
     GROUP BY al.snapshot_id
 )
@@ -165,7 +259,7 @@ SELECT
     a.profit / NULLIF(a.cost, 0) * 100                          AS unrealized_pnl_pct,
     NULL::FLOAT                                                  AS realized_pnl,
     a.value / NULLIF(acc.investments_total_cost + acc.investments_unrealized_pnl, 0) * 100
-                                                                AS position_weight_pct,
+                                                                 AS position_weight_pct,
     a.fx_impact,
 
     -- fact_return
@@ -192,6 +286,10 @@ SELECT
     a.recent_profit_low_30d,
     a.recent_value_high_30d,
     a.recent_value_low_30d,
+
+    -- fact_technical (FRED)
+    a.beta_60d,
+    a.sharpe_ratio_30d,
 
     -- fact_signal
     a.price / NULLIF(a.avg_price, 0)                            AS dca_bias,
@@ -223,10 +321,16 @@ SELECT
     (acc.total_value - acc.cash_available_to_trade)
         / NULLIF(acc.total_value, 0) * 100                      AS cash_deployment_ratio,
     pa.fx_impact_total,
-    pa.portfolio_volatility_weighted
+    pa.portfolio_volatility_weighted,
+    pa.portfolio_beta_weighted,
+
+    -- fact_portfolio_daily (FRED)
+    pm.sharpe_ratio_30d                                      AS acct_sharpe_ratio_30d,
+    pm.benchmark_return_daily                                 AS acct_benchmark_return_daily,
+    pm.portfolio_vs_benchmark_30d                             AS acct_portfolio_vs_benchmark_30d
 
 FROM asset_latest a
-JOIN account_ranked acc ON acc.snapshot_id = a.snapshot_id
+JOIN account_with_fred acc ON acc.snapshot_id = a.snapshot_id
 JOIN analytics.dim_asset da
     ON da.ticker = a.ticker
 CROSS JOIN (
@@ -235,4 +339,5 @@ CROSS JOIN (
     WHERE portfolio_id = :portfolio_id
 ) dp
 LEFT JOIN portfolio_agg pa ON pa.snapshot_id = a.snapshot_id
+LEFT JOIN portfolio_metrics pm ON pm.snapshot_id = a.snapshot_id
 WHERE a.rn = 1

--- a/src/pipelines/infrastructure/queries/portfolio/asset_portfolio_source.sql
+++ b/src/pipelines/infrastructure/queries/portfolio/asset_portfolio_source.sql
@@ -1,0 +1,10 @@
+SELECT ticker, name, broker, currency
+FROM (
+    SELECT *,
+          ROW_NUMBER() OVER (
+              PARTITION BY ticker, broker, currency
+              ORDER BY data_timestamp DESC
+          ) as rn
+    FROM staging.asset
+) t
+WHERE rn = 1;

--- a/src/pipelines/infrastructure/queries/portfolio/asset_portfolio_upsert.sql
+++ b/src/pipelines/infrastructure/queries/portfolio/asset_portfolio_upsert.sql
@@ -1,0 +1,20 @@
+MERGE INTO {destination_table_name} AS tgt
+USING
+  (
+    VALUES
+      {values}
+  )
+AS src (ticker, name, broker, currency)
+ON    tgt.ticker = src.ticker
+  AND tgt.broker = src.broker
+  AND tgt.currency = src.currency
+WHEN NOT MATCHED THEN
+  INSERT (ticker, name, broker, currency)
+  VALUES (src.ticker, src.name, src.broker, src.currency)
+WHEN MATCHED AND tgt.name <> src.name THEN
+UPDATE
+  SET   name = src.name
+      , updated_timestamp = NOW()
+WHEN NOT MATCHED BY SOURCE THEN
+  UPDATE
+    SET to_timestamp = NOW();

--- a/src/pipelines/infrastructure/queries/portfolio/sync_asset_tag.sql
+++ b/src/pipelines/infrastructure/queries/portfolio/sync_asset_tag.sql
@@ -1,0 +1,18 @@
+UPDATE {target}
+SET to_timestamp = CURRENT_DATE
+  , is_current = false
+FROM {target} as tgt
+    LEFT JOIN {source} src
+    ON tgt.asset_id = src.asset_id
+    AND tgt.tag_id = src.tag_id
+WHERE tgt.is_current = true
+  AND tgt.id IS NULL;
+
+INSERT INTO {target} (asset_id, tag_id)
+SELECT src.asset_id, src.tag_id
+FROM {target} tgt
+  RIGHT JOIN {source} src
+      ON tgt.asset_id = src.asset_id
+      AND tgt.tag_id = src.tag_id
+      AND tgt.is_current = true
+WHERE tgt.tag_id IS NULL AND tgt.asset_id IS NULL;

--- a/src/pipelines/infrastructure/queries/portfolio/sync_category.sql
+++ b/src/pipelines/infrastructure/queries/portfolio/sync_category.sql
@@ -1,0 +1,20 @@
+UPDATE {target}
+SET to_timestamp = CURRENT_DATE
+  , is_current = false
+FROM {target} as tgt
+  INNER JOIN {source} src
+    ON tgt.category_id = src.id
+WHERE tgt.is_current = true
+  AND (
+      tgt.name <> src.name
+    OR
+      tgt.description <> src.description
+  );
+
+INSERT INTO {target} (category_id, name, description)
+SELECT src.id, src.name, src.description
+FROM {target} tgt
+  RIGHT JOIN {source} src
+    ON tgt.category_id = src.id
+      AND tgt.is_current = true
+WHERE tgt.category_id IS NULL;

--- a/src/pipelines/infrastructure/queries/portfolio/sync_industry.sql
+++ b/src/pipelines/infrastructure/queries/portfolio/sync_industry.sql
@@ -1,0 +1,20 @@
+UPDATE {target}
+SET to_timestamp = CURRENT_DATE
+  , is_current = false
+FROM {target} as tgt
+  INNER JOIN {source} src
+    ON tgt.industry_id = src.id
+WHERE tgt.is_current = true
+  AND (
+      tgt.name <> src.name
+    OR
+      tgt.description <> src.description
+  );
+
+INSERT INTO {target} (industry_id, name, description)
+SELECT src.id, src.name, src.description
+FROM {target} tgt
+  RIGHT JOIN {source} src
+    ON tgt.industry_id = src.id
+      AND tgt.is_current = true
+WHERE tgt.industry_id IS NULL;

--- a/src/pipelines/infrastructure/queries/portfolio/sync_sector.sql
+++ b/src/pipelines/infrastructure/queries/portfolio/sync_sector.sql
@@ -1,0 +1,22 @@
+UPDATE {target}
+SET to_timestamp = CURRENT_DATE
+  , is_current = false
+FROM {target} as tgt
+  INNER JOIN {source} src
+    ON tgt.sector_id = src.id
+WHERE tgt.is_current = true
+  AND (
+      tgt.name <> src.name
+    OR
+      tgt.industry_id <> src.industry_id
+    OR
+      tgt.description <> src.description
+  );
+
+INSERT INTO {target} (sector_id, industry_id, name, description)
+SELECT src.id, src.industry_id, src.name, src.description
+FROM {target} tgt
+  RIGHT JOIN {source} src
+    ON tgt.sector_id = src.id
+      AND tgt.is_current = true
+WHERE tgt.sector_id IS NULL;

--- a/src/pipelines/infrastructure/queries/portfolio/sync_tag.sql
+++ b/src/pipelines/infrastructure/queries/portfolio/sync_tag.sql
@@ -1,0 +1,22 @@
+UPDATE {target}
+SET to_timestamp = CURRENT_DATE
+  , is_current = false
+FROM {target} as tgt
+  INNER JOIN {source} src
+    ON tgt.tag_id = src.id
+WHERE tgt.is_current = true
+  AND (
+      tgt.name <> src.name
+    OR
+      tgt.category_id <> src.category_id
+    OR
+      tgt.description <> src.description
+  );
+
+INSERT INTO {target} (tag_id, name, description, category_id)
+SELECT src.id, src.name, src.description, src.category_id
+FROM {target} tgt
+  RIGHT JOIN {source} src
+    ON tgt.tag_id = src.id
+      AND tgt.is_current = true
+WHERE tgt.tag_id IS NULL;

--- a/src/pipelines/infrastructure/queries/silver/fred_observation_start.sql
+++ b/src/pipelines/infrastructure/queries/silver/fred_observation_start.sql
@@ -1,0 +1,3 @@
+SELECT MAX(observation_date) AS max_date
+FROM staging.fred_observation
+WHERE series_id = :series_id


### PR DESCRIPTION
Moves 16 inline SQL blocks from runner/loader modules into dedicated .sql files loaded via shared.database.query_loader, matching the pattern already in use for silver/gold source queries. Structural names use .format(); values stay bound via :param.

## Summary

<!-- Briefly describe what this PR does and why -->

Closes #<!-- issue number -->

## Checklist

- [ ] Linked to a GitHub issue
- [ ] Scoped to a single architectural layer
- [ ] Tests written and passing
- [ ] No unresolved TODOs left in the diff
- [ ] Documentation updated if behaviour changed
- [ ] Self-reviewed before requesting a reviewer
