### PR TITLE
feat(ui): add asset name to chart tooltips and daily movers table

### DIFF
--- a/frontend/src/components/charts/DailyMoversTable.tsx
+++ b/frontend/src/components/charts/DailyMoversTable.tsx
@@ -1,7 +1,7 @@
 import { Box, Table, TableBody, TableCell, TableHead, TableRow, useTheme } from '@mui/material'
 
 interface DailyMoversTableProps {
-  movers?: Array<{ ticker: string; daily_value_return: number }>
+  movers?: Array<{ ticker: string; daily_value_return: number; name: string }>
 }
 
 export default function DailyMoversTable({ movers }: DailyMoversTableProps) {
@@ -14,6 +14,7 @@ export default function DailyMoversTable({ movers }: DailyMoversTableProps) {
         <TableHead>
           <TableRow>
             <TableCell sx={{ fontSize: 11, fontWeight: 700 }}>Ticker</TableCell>
+            <TableCell sx={{ fontSize: 11, fontWeight: 700 }}>Name</TableCell>
             <TableCell align="right" sx={{ fontSize: 11, fontWeight: 700 }}>Daily Return</TableCell>
           </TableRow>
         </TableHead>
@@ -21,6 +22,19 @@ export default function DailyMoversTable({ movers }: DailyMoversTableProps) {
           {movers.map((m) => (
             <TableRow key={m.ticker} hover>
               <TableCell sx={{ fontSize: 11 }}>{m.ticker}</TableCell>
+              <TableCell
+                sx={{
+                  fontSize: 11,
+                  color: theme.palette.text.secondary,
+                  maxWidth: 180,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+                title={m.name}
+              >
+                {m.name}
+              </TableCell>
               <TableCell
                 align="right"
                 sx={{

--- a/frontend/src/components/charts/LosersChart.tsx
+++ b/frontend/src/components/charts/LosersChart.tsx
@@ -1,25 +1,40 @@
 import { useTheme } from '@mui/material'
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
-import { useTooltipStyle, fmtNum } from '../../utils/chartUtils'
+import { fmtNum } from '../../utils/chartUtils'
+
+interface LoserItem {
+  ticker: string
+  profit: number
+  label: string
+  name: string
+}
 
 interface LosersChartProps {
-  losers?: Array<{ ticker: string; profit: number; label: string }>
+  losers?: LoserItem[]
 }
 
 export default function LosersChart({ losers }: LosersChartProps) {
   const theme = useTheme()
-  const tooltipStyle = useTooltipStyle()
   if (!losers?.length) return null
+
+  function CustomTooltip({ active, payload }: { active?: boolean; payload?: unknown[] }) {
+    if (!active || !payload?.length) return null
+    const d = (payload as Array<{ payload: LoserItem }>)[0].payload
+    return (
+      <div style={{ background: theme.palette.background.paper, border: `1px solid ${theme.palette.divider}`, padding: '6px 10px', fontSize: 11, borderRadius: 4 }}>
+        <div style={{ fontWeight: 600 }}>{d.ticker}</div>
+        <div style={{ color: theme.palette.text.secondary, fontSize: 10, marginBottom: 2 }}>{d.name}</div>
+        <div>P&L: {fmtNum(d.profit)}</div>
+      </div>
+    )
+  }
 
   return (
     <ResponsiveContainer width="100%" height={200}>
       <BarChart data={losers} layout="vertical" margin={{ top: 4, right: 16, bottom: 4, left: 0 }}>
         <XAxis type="number" tick={{ fontSize: 10 }} tickLine={false} />
         <YAxis type="category" dataKey="label" tick={{ fontSize: 10 }} width={60} />
-        <Tooltip
-          contentStyle={tooltipStyle}
-          formatter={(v: unknown) => [fmtNum(v), 'P&L']}
-        />
+        <Tooltip content={<CustomTooltip />} cursor={{ fill: theme.palette.action.hover }} />
         <Bar dataKey="profit" radius={[0, 3, 3, 0]}>
           {losers.map((_, i) => (
             <Cell key={i} fill={theme.palette.error.main} opacity={1 - i * 0.06} />

--- a/frontend/src/components/charts/OpportunitiesChart.tsx
+++ b/frontend/src/components/charts/OpportunitiesChart.tsx
@@ -40,6 +40,7 @@ export default function OpportunitiesChart({ distribution }: OpportunitiesChartP
     return (
       <div style={{ background: theme.palette.background.paper, border: `1px solid ${theme.palette.divider}`, padding: '6px 10px', fontSize: 11, borderRadius: 4 }}>
         <div style={{ fontWeight: 600 }}>{d.ticker}</div>
+        <div style={{ color: theme.palette.text.secondary, fontSize: 10, marginBottom: 2 }}>{d.name}</div>
         <div>Weight: {d.weight_pct.toFixed(1)}%</div>
         <div>ROI: {d.roi_pct > 0 ? '+' : ''}{d.roi_pct.toFixed(2)}%</div>
         <div>P&L: {fmtNum(d.profit)}</div>

--- a/frontend/src/components/charts/PositionPerformanceMap.tsx
+++ b/frontend/src/components/charts/PositionPerformanceMap.tsx
@@ -220,7 +220,7 @@ export default function PositionPerformanceMap({
           content={(props) => (
             <CustomTooltip
               active={props.active}
-              payload={props.payload as Array<{ payload: EnrichedPoint }>}
+              payload={props.payload as unknown as Array<{ payload: EnrichedPoint }>}
               currencySymbol={currencySymbol}
             />
           )}

--- a/frontend/src/components/charts/PositionWeightChart.tsx
+++ b/frontend/src/components/charts/PositionWeightChart.tsx
@@ -1,9 +1,16 @@
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts'
 import { useTheme } from '@mui/material'
-import { useTooltipStyle } from '../../utils/chartUtils'
+
+interface DistributionItem {
+  ticker: string
+  weight_pct: number
+  profit: number
+  value: number
+  name: string
+}
 
 interface PositionWeightChartProps {
-  distribution?: Array<{ ticker: string; weight_pct: number; profit: number; value: number }>
+  distribution?: DistributionItem[]
 }
 
 // Reordered so high-contrast colors are never adjacent in the ring
@@ -23,13 +30,24 @@ const PALETTE = [
 
 export default function PositionWeightChart({ distribution }: PositionWeightChartProps) {
   const theme = useTheme()
-  const tooltipStyle = useTooltipStyle()
   if (!distribution?.length) return null
 
   const sorted = [...distribution].sort((a, b) => b.weight_pct - a.weight_pct).slice(0, 10)
 
   const textSecondary = theme.palette.text.secondary
   const textPrimary = theme.palette.text.primary
+
+  function CustomTooltip({ active, payload }: { active?: boolean; payload?: unknown[] }) {
+    if (!active || !payload?.length) return null
+    const d = (payload as Array<{ payload: DistributionItem }>)[0].payload
+    return (
+      <div style={{ background: theme.palette.background.paper, border: `1px solid ${theme.palette.divider}`, padding: '6px 10px', fontSize: 11, borderRadius: 4 }}>
+        <div style={{ fontWeight: 600 }}>{d.ticker}</div>
+        <div style={{ color: textSecondary, fontSize: 10, marginBottom: 2 }}>{d.name}</div>
+        <div>Weight: {d.weight_pct.toFixed(2)}%</div>
+      </div>
+    )
+  }
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%', height: 300, padding: '10px' }}>
@@ -51,10 +69,7 @@ export default function PositionWeightChart({ distribution }: PositionWeightChar
                 <Cell key={i} fill={PALETTE[i % PALETTE.length]} />
               ))}
             </Pie>
-            <Tooltip
-              contentStyle={tooltipStyle}
-              formatter={(v: unknown) => [`${Number(v).toFixed(2)}%`, 'Weight']}
-            />
+            <Tooltip content={<CustomTooltip />} />
           </PieChart>
         </ResponsiveContainer>
       </div>

--- a/frontend/src/components/charts/VarByPositionChart.tsx
+++ b/frontend/src/components/charts/VarByPositionChart.tsx
@@ -1,15 +1,31 @@
 import { useTheme } from '@mui/material'
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Cell } from 'recharts'
-import { useTooltipStyle } from '../../utils/chartUtils'
+
+interface VarItem {
+  ticker: string
+  var_95_1d: number
+  name: string
+}
 
 interface VarByPositionChartProps {
-  varData?: Array<{ ticker: string; var_95_1d: number }>
+  varData?: VarItem[]
 }
 
 export default function VarByPositionChart({ varData }: VarByPositionChartProps) {
   const theme = useTheme()
-  const tooltipStyle = useTooltipStyle()
   if (!varData?.length) return null
+
+  function CustomTooltip({ active, payload }: { active?: boolean; payload?: unknown[] }) {
+    if (!active || !payload?.length) return null
+    const d = (payload as Array<{ payload: VarItem }>)[0].payload
+    return (
+      <div style={{ background: theme.palette.background.paper, border: `1px solid ${theme.palette.divider}`, padding: '6px 10px', fontSize: 11, borderRadius: 4 }}>
+        <div style={{ fontWeight: 600 }}>{d.ticker}</div>
+        <div style={{ color: theme.palette.text.secondary, fontSize: 10, marginBottom: 2 }}>{d.name}</div>
+        <div>VaR 95% 1d: {d.var_95_1d.toFixed(4)}</div>
+      </div>
+    )
+  }
 
   return (
     <ResponsiveContainer width="100%" height={200}>
@@ -17,10 +33,7 @@ export default function VarByPositionChart({ varData }: VarByPositionChartProps)
         <CartesianGrid strokeDasharray="3 3" stroke={theme.palette.divider} />
         <XAxis dataKey="ticker" tick={{ fontSize: 10 }} tickLine={false} />
         <YAxis tick={{ fontSize: 10 }} tickLine={false} width={55} />
-        <Tooltip
-          contentStyle={tooltipStyle}
-          formatter={(v: unknown) => [Number(v).toFixed(4), 'VaR 95% 1d']}
-        />
+        <Tooltip content={<CustomTooltip />} cursor={{ fill: theme.palette.action.hover }} />
         <Bar dataKey="var_95_1d" radius={[3, 3, 0, 0]}>
           {varData.map((_, i) => (
             <Cell key={i} fill={theme.palette.error.main} opacity={0.9 - i * 0.06} />

--- a/frontend/src/components/charts/WinnersChart.tsx
+++ b/frontend/src/components/charts/WinnersChart.tsx
@@ -1,25 +1,40 @@
 import { useTheme } from '@mui/material'
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
-import { useTooltipStyle, fmtNum } from '../../utils/chartUtils'
+import { fmtNum } from '../../utils/chartUtils'
+
+interface WinnerItem {
+  ticker: string
+  profit: number
+  label: string
+  name: string
+}
 
 interface WinnersChartProps {
-  winners?: Array<{ ticker: string; profit: number; label: string }>
+  winners?: WinnerItem[]
 }
 
 export default function WinnersChart({ winners }: WinnersChartProps) {
   const theme = useTheme()
-  const tooltipStyle = useTooltipStyle()
   if (!winners?.length) return null
+
+  function CustomTooltip({ active, payload }: { active?: boolean; payload?: unknown[] }) {
+    if (!active || !payload?.length) return null
+    const d = (payload as Array<{ payload: WinnerItem }>)[0].payload
+    return (
+      <div style={{ background: theme.palette.background.paper, border: `1px solid ${theme.palette.divider}`, padding: '6px 10px', fontSize: 11, borderRadius: 4 }}>
+        <div style={{ fontWeight: 600 }}>{d.ticker}</div>
+        <div style={{ color: theme.palette.text.secondary, fontSize: 10, marginBottom: 2 }}>{d.name}</div>
+        <div>Profit: {fmtNum(d.profit)}</div>
+      </div>
+    )
+  }
 
   return (
     <ResponsiveContainer width="100%" height={200}>
       <BarChart data={winners} layout="vertical" margin={{ top: 4, right: 16, bottom: 4, left: 0 }}>
         <XAxis type="number" tick={{ fontSize: 10 }} tickLine={false} />
         <YAxis type="category" dataKey="label" tick={{ fontSize: 10 }} width={60} />
-        <Tooltip
-          contentStyle={tooltipStyle}
-          formatter={(v: unknown) => [fmtNum(v), 'Profit']}
-        />
+        <Tooltip content={<CustomTooltip />} cursor={{ fill: theme.palette.action.hover }} />
         <Bar dataKey="profit" radius={[0, 3, 3, 0]}>
           {winners.map((_, i) => (
             <Cell key={i} fill={theme.palette.success.main} opacity={1 - i * 0.06} />

--- a/src/dashboard/presenters/portfolio_presenter.py
+++ b/src/dashboard/presenters/portfolio_presenter.py
@@ -124,6 +124,7 @@ class PortfolioPresenter:
                 "ticker": a["ticker"],
                 "var_95_1d": float(a["var_95_1d"]),
                 "label": a["ticker"],
+                "name": a["name"],
             }
             for a in assets
             if a.get("var_95_1d") is not None
@@ -147,6 +148,7 @@ class PortfolioPresenter:
                     "ticker": a["ticker"],
                     "daily_value_return": daily_value_return,
                     "label": a["ticker"],
+                    "name": a["name"],
                 }
             )
 


### PR DESCRIPTION
All identified charts now show the full asset name below the ticker in hover tooltips, so users can identify positions without memorising codes. Also adds a Name column to the Daily Movers table. Presenter updated to emit name for VaR and daily movers view-models.

## Summary

<!-- Briefly describe what this PR does and why -->

Closes #<!-- issue number -->

## Checklist

- [ ] Linked to a GitHub issue
- [ ] Scoped to a single architectural layer
- [ ] Tests written and passing
- [ ] No unresolved TODOs left in the diff
- [ ] Documentation updated if behaviour changed
- [ ] Self-reviewed before requesting a reviewer
