### PR TITLE
feat(raw): ingest T212 historical events (dividends, orders, transactions)

### DIFF
--- a/migrations/postgres/versions/raw/005_raw_t212_history.py
+++ b/migrations/postgres/versions/raw/005_raw_t212_history.py
@@ -1,0 +1,78 @@
+"""005_raw_t212_history
+
+Revision ID: 1100000000a5
+Revises: 1100000000a4
+Create Date: 2026-04-20
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1100000000a5'
+down_revision: Union[str, Sequence[str], None] = '1100000000a4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS raw.t212_history_dividend (
+            id                  TEXT NOT NULL,
+            ingested_date       DATE NOT NULL,
+            ingested_timestamp  TIMESTAMPTZ DEFAULT now(),
+            payload             JSONB NOT NULL,
+            processed_at        TIMESTAMPTZ,
+            PRIMARY KEY (id, ingested_date)
+        )
+        PARTITION BY RANGE (ingested_date);
+
+        CREATE INDEX IF NOT EXISTS idx_raw_t212_history_dividend_ingested_date
+        ON raw.t212_history_dividend (ingested_date);
+
+        CREATE TABLE IF NOT EXISTS raw.t212_history_order (
+            id                  TEXT NOT NULL,
+            ingested_date       DATE NOT NULL,
+            ingested_timestamp  TIMESTAMPTZ DEFAULT now(),
+            payload             JSONB NOT NULL,
+            processed_at        TIMESTAMPTZ,
+            PRIMARY KEY (id, ingested_date)
+        )
+        PARTITION BY RANGE (ingested_date);
+
+        CREATE INDEX IF NOT EXISTS idx_raw_t212_history_order_ingested_date
+        ON raw.t212_history_order (ingested_date);
+
+        CREATE TABLE IF NOT EXISTS raw.t212_history_transaction (
+            id                  TEXT NOT NULL,
+            ingested_date       DATE NOT NULL,
+            ingested_timestamp  TIMESTAMPTZ DEFAULT now(),
+            payload             JSONB NOT NULL,
+            processed_at        TIMESTAMPTZ,
+            PRIMARY KEY (id, ingested_date)
+        )
+        PARTITION BY RANGE (ingested_date);
+
+        CREATE INDEX IF NOT EXISTS idx_raw_t212_history_transaction_ingested_date
+        ON raw.t212_history_transaction (ingested_date);
+
+        CREATE TABLE IF NOT EXISTS raw.t212_history_cursor (
+            endpoint       TEXT PRIMARY KEY,
+            last_cursor    TEXT,
+            last_event_ts  TIMESTAMPTZ,
+            updated_at     TIMESTAMPTZ DEFAULT now()
+        );
+    """)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("""
+        DROP TABLE IF EXISTS raw.t212_history_cursor CASCADE;
+        DROP TABLE IF EXISTS raw.t212_history_transaction CASCADE;
+        DROP TABLE IF EXISTS raw.t212_history_order CASCADE;
+        DROP TABLE IF EXISTS raw.t212_history_dividend CASCADE;
+    """)

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -18,6 +18,14 @@ deployments:
       - interval: 3600          # hourly
         anchor_date: "2024-01-01T00:00:00Z"
 
+  - name: t212_history_bronze
+    entrypoint: ./src/orchestration/prefect/flow_t212_history_bronze.py:flow_t212_history_bronze
+    work_pool:
+      name: asset-monitoring-pool
+    schedules:
+      - interval: 3600          # hourly
+        anchor_date: "2024-01-01T00:00:00Z"
+
   - name: t212_silver
     entrypoint: ./src/orchestration/prefect/flow_t212_silver.py:flow_t212_silver
     work_pool:

--- a/src/orchestration/prefect/flow_t212_history_bronze.py
+++ b/src/orchestration/prefect/flow_t212_history_bronze.py
@@ -1,0 +1,20 @@
+from prefect import flow, task
+from prefect.logging import loggers
+from prefect.cache_policies import NO_CACHE
+from pipelines.factories.pipeline_factory import PipelineFactory
+
+logger = loggers.get_logger(__name__)
+
+
+@task(retry_delay_seconds=60, retries=2, cache_policy=NO_CACHE)
+def task_trading212_history_bronze():
+    pipeline = PipelineFactory.get("t212_history_bronze")
+    logger.info("Running Trading212 history bronze pipeline")
+    pipeline.run()
+
+
+@flow
+def flow_t212_history_bronze():
+    logger.info("Ingestion Trading212 history events")
+    task_trading212_history_bronze()
+    logger.info("flow complete")

--- a/src/pipelines/application/runners/loaders/loader_bronze_t212_history.py
+++ b/src/pipelines/application/runners/loaders/loader_bronze_t212_history.py
@@ -1,0 +1,107 @@
+import os
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from dotenv import load_dotenv
+
+from ....application.policies import FullLoader
+from shared.database.client import SQLModelClient
+from shared.database.query_loader import load_query
+
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+_QUERIES_DIR = Path(__file__).parent.parent.parent.parent / "infrastructure" / "queries"
+
+_ENDPOINT_TABLES = {
+    "dividends": "raw.t212_history_dividend",
+    "orders": "raw.t212_history_order",
+    "transactions": "raw.t212_history_transaction",
+}
+
+
+class FullLoaderPostgresT212History(FullLoader):
+    """
+    Loads paginated T212 history (dividends, orders, transactions) into three
+    raw tables partitioned by ingested_date, and upserts per-endpoint cursor
+    state into raw.t212_history_cursor for incremental pulls.
+
+    Data shape expected by _loader:
+        {
+            "dividends":    [ {raw_api_item}, ... ],
+            "orders":       [ ... ],
+            "transactions": [ ... ],
+            "cursors": {
+                "dividends":    {"last_cursor": str|None, "last_event_ts": datetime|None},
+                "orders":       {...},
+                "transactions": {...},
+            },
+        }
+    """
+
+    def __init__(self):
+        # _table_name is logical — this loader manages three tables.
+        super().__init__("raw.t212_history")
+        self._client = SQLModelClient(DATABASE_URL)
+
+    def _create_partition(self):
+        sql_template = load_query(_QUERIES_DIR / "bronze" / "create_partition.sql")
+        with self._client as client:
+            for table in _ENDPOINT_TABLES.values():
+                partition_name = f"{table}_{self._day}"
+                sql = sql_template.format(
+                    partition_name=partition_name,
+                    table_name=table,
+                )
+                client.execute(sql, {"day": self._day, "next_day": self._next_day})
+
+    def _loader(self, data: dict):
+        ingested_date = datetime.now().date()
+        insert_sql_template = load_query(
+            _QUERIES_DIR / "bronze" / "t212_history_insert.sql"
+        )
+        cursor_sql = load_query(
+            _QUERIES_DIR / "bronze" / "t212_history_cursor_upsert.sql"
+        )
+
+        with self._client as client:
+            for endpoint, table in _ENDPOINT_TABLES.items():
+                items = data.get(endpoint, []) or []
+                if items:
+                    insert_sql = insert_sql_template.format(table_name=table)
+                    for item in items:
+                        row_id = self._extract_id(endpoint, item)
+                        if row_id is None:
+                            logging.warning(
+                                f"[{endpoint}] skipping item without id key: {list(item.keys())}"
+                            )
+                            continue
+                        client.execute(
+                            insert_sql,
+                            params={
+                                "id": str(row_id),
+                                "ingested_date": ingested_date,
+                                "payload": json.dumps(item),
+                            },
+                        )
+
+                cursor = (data.get("cursors") or {}).get(endpoint) or {}
+                if cursor.get("last_cursor") is not None or cursor.get("last_event_ts") is not None:
+                    client.execute(
+                        cursor_sql,
+                        params={
+                            "endpoint": endpoint,
+                            "last_cursor": cursor.get("last_cursor"),
+                            "last_event_ts": cursor.get("last_event_ts"),
+                        },
+                    )
+
+    @staticmethod
+    def _extract_id(endpoint: str, item: dict):
+        # dividends + transactions: `reference` (string)
+        # orders: `id` (int64)  → cast to str for TEXT column
+        if endpoint == "orders":
+            return item.get("id")
+        return item.get("reference")

--- a/src/pipelines/application/runners/loaders/loader_bronze_t212_history.py
+++ b/src/pipelines/application/runners/loaders/loader_bronze_t212_history.py
@@ -100,8 +100,8 @@ class FullLoaderPostgresT212History(FullLoader):
 
     @staticmethod
     def _extract_id(endpoint: str, item: dict):
-        # dividends + transactions: `reference` (string)
-        # orders: `id` (int64)  → cast to str for TEXT column
+        # dividends + transactions: top-level `reference` (string)
+        # orders: HistoricalOrder wraps {order, fill} — id is nested under `order`
         if endpoint == "orders":
-            return item.get("id")
+            return (item.get("order") or {}).get("id")
         return item.get("reference")

--- a/src/pipelines/application/runners/pipeline_bronze_t212_history.py
+++ b/src/pipelines/application/runners/pipeline_bronze_t212_history.py
@@ -1,0 +1,209 @@
+"""
+Bronze Pipeline for Trading212 historical events.
+
+Ingests three cursor-paginated endpoints into separate raw tables:
+  - /equity/history/dividends     → raw.t212_history_dividend
+  - /equity/history/orders        → raw.t212_history_order
+  - /equity/history/transactions  → raw.t212_history_transaction
+
+Per-endpoint high-water marks are stored in raw.t212_history_cursor and used
+to stop pagination once a page's oldest event is at or before the last seen
+event timestamp, so steady-state runs are cheap under the 6 req/min limit.
+"""
+
+import os
+import logging
+import asyncio
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+from dotenv import load_dotenv
+
+from ...application.protocols import Source, Destination
+from ...application.policies import Pipeline
+
+from .loaders.loader_bronze_t212_history import FullLoaderPostgresT212History
+
+from ...infrastructure.clients.api_client_trading212 import Trading212APIClient
+
+from shared.database.client import SQLModelClient
+from shared.database.query_loader import load_query
+
+logging.basicConfig(
+    level=logging.INFO,
+    filename="logs/info.log",
+    filemode="a",
+    format="%(asctime)s - %(levelname)s - %(filename)s - %(message)s",
+)
+
+load_dotenv()
+
+URL = os.getenv("API_URL")
+API_TOKEN = os.getenv("API_TOKEN")
+SECRET_TOKEN = os.getenv("SECRET_TOKEN")
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+_QUERIES_DIR = Path(__file__).parent.parent.parent / "infrastructure" / "queries"
+
+_ENDPOINTS = {
+    "dividends":    "equity/history/dividends",
+    "orders":       "equity/history/orders",
+    "transactions": "equity/history/transactions",
+}
+
+_EVENT_TS_KEY = {
+    "dividends":    "paidOn",
+    "orders":       None,  # nested — handled in _item_event_ts
+    "transactions": "dateTime",
+}
+
+
+def _parse_ts(value):
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _item_event_ts(endpoint: str, item: dict):
+    """Best-effort event timestamp extraction. Returns None if unavailable."""
+    if endpoint == "orders":
+        order = (item or {}).get("order") or {}
+        return _parse_ts(order.get("createdAt"))
+    key = _EVENT_TS_KEY.get(endpoint)
+    if key is None:
+        return None
+    return _parse_ts((item or {}).get(key))
+
+
+# ─────────────────────────────────────────────
+# Source
+# ─────────────────────────────────────────────
+
+
+class Trading212HistorySource(Source):
+    def __init__(self):
+        self._api_client = Trading212APIClient(URL, API_TOKEN, SECRET_TOKEN)
+        self._db_client = SQLModelClient(DATABASE_URL)
+
+    def extract(self) -> dict:
+        result: dict[str, Any] = {"cursors": {}}
+
+        for endpoint_key, path in _ENDPOINTS.items():
+            try:
+                stored_ts = self._get_stored_high_water_mark(endpoint_key)
+                items, newest_ts, newest_cursor = asyncio.run(
+                    self._pull_endpoint(endpoint_key, path, stored_ts)
+                )
+                result[endpoint_key] = items
+                result["cursors"][endpoint_key] = {
+                    "last_cursor": newest_cursor,
+                    "last_event_ts": newest_ts or stored_ts,
+                }
+                logging.info(
+                    f"[t212_history:{endpoint_key}] fetched {len(items)} items; "
+                    f"new high-water mark: {newest_ts or stored_ts}"
+                )
+            except Exception as e:
+                # Isolate endpoint failures so one broken stream doesn't poison the others.
+                logging.exception(f"[t212_history:{endpoint_key}] extraction failed: {e}")
+                result[endpoint_key] = []
+                result["cursors"][endpoint_key] = {}
+
+        return result
+
+    async def _pull_endpoint(self, endpoint_key: str, path: str, stored_ts):
+        """Page through endpoint, collecting items newer than stored_ts."""
+        collected: list[dict] = []
+        newest_ts = None
+        newest_cursor = None
+
+        def stop_once_page_is_older(page: dict) -> bool:
+            if stored_ts is None:
+                return False
+            items = page.get("items") or []
+            if not items:
+                return True
+            oldest = min(
+                (ts for ts in (_item_event_ts(endpoint_key, i) for i in items) if ts is not None),
+                default=None,
+            )
+            if oldest is None:
+                return False
+            return oldest <= stored_ts
+
+        async for page in self._api_client.get_paginated(
+            endpoint=path,
+            stop_predicate=stop_once_page_is_older,
+        ):
+            items = page.get("items") or []
+            for item in items:
+                ts = _item_event_ts(endpoint_key, item)
+                if stored_ts is not None and ts is not None and ts <= stored_ts:
+                    continue  # already seen in a previous run
+                collected.append(item)
+                if ts is not None and (newest_ts is None or ts > newest_ts):
+                    newest_ts = ts
+
+            next_path = page.get("nextPagePath")
+            if next_path and "cursor=" in next_path and newest_cursor is None:
+                # Stash the first nextPagePath's cursor as opaque observability state.
+                newest_cursor = next_path.split("cursor=")[-1].split("&")[0]
+
+        return collected, newest_ts, newest_cursor
+
+    def _get_stored_high_water_mark(self, endpoint_key: str):
+        sql = load_query(_QUERIES_DIR / "bronze" / "t212_history_cursor_select.sql")
+        with self._db_client as client:
+            result = client.execute(sql, params={"endpoint": endpoint_key})
+            row = result.fetchone() if result is not None else None
+        if row is None:
+            return None
+        return _parse_ts(getattr(row, "last_event_ts", None))
+
+
+# ─────────────────────────────────────────────
+# Destination
+# ─────────────────────────────────────────────
+
+
+class Trading212HistoryDestination(Destination):
+    def load(self, data: Any) -> None:
+        FullLoaderPostgresT212History().load(data)
+
+
+# ─────────────────────────────────────────────
+# Pipeline
+# ─────────────────────────────────────────────
+
+
+class PipelineT212History(Pipeline):
+    def __init__(self):
+        self._source = Trading212HistorySource()
+        self._destination = Trading212HistoryDestination()
+
+    def run(self):
+        try:
+            data = self._source.extract()
+            if not self._has_payload(data):
+                logging.info("[t212_history] no new events; skipping load")
+                return None
+            self._destination.load(data)
+            return None
+        except Exception as e:
+            raise e
+
+    @staticmethod
+    def _has_payload(data: dict) -> bool:
+        for key in _ENDPOINTS:
+            if data.get(key):
+                return True
+        return False
+
+
+if __name__ == "__main__":
+    PipelineT212History().run()

--- a/src/pipelines/application/runners/pipeline_bronze_t212_history.py
+++ b/src/pipelines/application/runners/pipeline_bronze_t212_history.py
@@ -16,7 +16,7 @@ import logging
 import asyncio
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 from dotenv import load_dotenv
 
 from ...application.protocols import Source, Destination

--- a/src/pipelines/factories/pipeline_factory.py
+++ b/src/pipelines/factories/pipeline_factory.py
@@ -5,6 +5,7 @@ from ..application.runners.portfolio_enrichment_synchronizer import (
     enrichment_sychronization,
 )
 from ..application.runners.pipeline_bronze_t212 import PipelineT212Bronze
+from ..application.runners.pipeline_bronze_t212_history import PipelineT212History
 from ..application.runners.pipeline_silver_t212 import PipelineT212Silver
 from ..application.runners.pipeline_gold_t212 import PipelineT212Gold
 from ..application.runners.pipeline_bronze_fred import PipelineFredBronze
@@ -16,6 +17,7 @@ class PipelineFactory:
         "asset_portfolio": PipelineAssetPortfolio,
         "enrichment_sychronization": enrichment_sychronization,
         "t212_bronze": PipelineT212Bronze,
+        "t212_history_bronze": PipelineT212History,
         "t212_silver": PipelineT212Silver,
         "t212_gold": PipelineT212Gold,
         "fred_bronze": PipelineFredBronze,

--- a/src/pipelines/infrastructure/clients/api_client_trading212.py
+++ b/src/pipelines/infrastructure/clients/api_client_trading212.py
@@ -1,7 +1,10 @@
 import os
+import asyncio
+import time
 import httpx
 import base64
 import logging
+from typing import AsyncIterator, Callable, Optional
 from urllib.parse import urljoin
 
 from ...application.interfaces.interface_api_client import APIClient
@@ -46,3 +49,47 @@ class Trading212APIClient(APIClient):
                     f"API call failed with status code {response.status_code}"
                 )
                 return {"error": response.status_code, "message": "API call failed"}
+
+    async def get_paginated(
+        self,
+        endpoint: str,
+        cursor: Optional[str] = None,
+        limit: int = 50,
+        stop_predicate: Optional[Callable[[dict], bool]] = None,
+    ) -> AsyncIterator[dict]:
+        """
+        Iterate T212 cursor-paginated endpoints following nextPagePath until
+        exhausted or stop_predicate(page) returns True.
+
+        On HTTP 429, reads x-ratelimit-reset and sleeps until reset.
+        On other non-200, raises httpx.HTTPStatusError rather than returning
+        an error-dict, so callers can safely loop on successful pages only.
+        """
+        header = {"Authorization": f"Basic {self.credentials()}"}
+
+        next_path = f"{endpoint}?limit={limit}"
+        if cursor is not None:
+            next_path = f"{next_path}&cursor={cursor}"
+
+        async with httpx.AsyncClient() as client:
+            while next_path:
+                url = urljoin(self.url, next_path)
+                logging.info(f"Paginated API call to {url}")
+                response = await client.get(url, headers=header)
+
+                if response.status_code == 429:
+                    reset = response.headers.get("x-ratelimit-reset")
+                    wait_s = max(int(reset) - int(time.time()), 1) if reset else 5
+                    logging.warning(f"Rate limited; sleeping {wait_s}s")
+                    await asyncio.sleep(wait_s)
+                    continue
+
+                response.raise_for_status()
+                page = response.json()
+
+                yield page
+
+                if stop_predicate is not None and stop_predicate(page):
+                    return
+
+                next_path = page.get("nextPagePath")

--- a/src/pipelines/infrastructure/queries/bronze/t212_history_cursor_select.sql
+++ b/src/pipelines/infrastructure/queries/bronze/t212_history_cursor_select.sql
@@ -1,0 +1,3 @@
+SELECT last_cursor, last_event_ts
+FROM raw.t212_history_cursor
+WHERE endpoint = :endpoint

--- a/src/pipelines/infrastructure/queries/bronze/t212_history_cursor_upsert.sql
+++ b/src/pipelines/infrastructure/queries/bronze/t212_history_cursor_upsert.sql
@@ -1,0 +1,16 @@
+INSERT INTO raw.t212_history_cursor (
+    endpoint,
+    last_cursor,
+    last_event_ts,
+    updated_at
+)
+VALUES (
+    :endpoint,
+    :last_cursor,
+    :last_event_ts,
+    now()
+)
+ON CONFLICT (endpoint) DO UPDATE SET
+    last_cursor   = EXCLUDED.last_cursor,
+    last_event_ts = EXCLUDED.last_event_ts,
+    updated_at    = now()

--- a/src/pipelines/infrastructure/queries/bronze/t212_history_insert.sql
+++ b/src/pipelines/infrastructure/queries/bronze/t212_history_insert.sql
@@ -1,0 +1,11 @@
+INSERT INTO {table_name} (
+    id,
+    ingested_date,
+    payload
+)
+VALUES (
+    :id,
+    :ingested_date,
+    :payload
+)
+ON CONFLICT (id, ingested_date) DO NOTHING

--- a/tests/ingestion/integration/conftest.py
+++ b/tests/ingestion/integration/conftest.py
@@ -1,0 +1,90 @@
+"""
+Integration-test fixtures for the T212 history raw ingestion.
+
+Connects to the Postgres instance defined in docker-compose.yml via the
+DATABASE_URL env var. If the DB is unreachable, tests that depend on these
+fixtures are skipped so CI runs without a DB still pass.
+
+The postgres_raw_history_schema fixture applies the 005 migration DDL
+directly (not via Alembic) and drops the tables on teardown, so each test
+run starts and ends clean without interfering with a developer's dev DB.
+"""
+
+import os
+
+import pytest
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, text
+
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+_CREATE_SQL = """
+CREATE SCHEMA IF NOT EXISTS raw;
+
+CREATE TABLE IF NOT EXISTS raw.t212_history_dividend (
+    id                  TEXT NOT NULL,
+    ingested_date       DATE NOT NULL,
+    ingested_timestamp  TIMESTAMPTZ DEFAULT now(),
+    payload             JSONB NOT NULL,
+    processed_at        TIMESTAMPTZ,
+    PRIMARY KEY (id, ingested_date)
+) PARTITION BY RANGE (ingested_date);
+
+CREATE TABLE IF NOT EXISTS raw.t212_history_order (
+    id                  TEXT NOT NULL,
+    ingested_date       DATE NOT NULL,
+    ingested_timestamp  TIMESTAMPTZ DEFAULT now(),
+    payload             JSONB NOT NULL,
+    processed_at        TIMESTAMPTZ,
+    PRIMARY KEY (id, ingested_date)
+) PARTITION BY RANGE (ingested_date);
+
+CREATE TABLE IF NOT EXISTS raw.t212_history_transaction (
+    id                  TEXT NOT NULL,
+    ingested_date       DATE NOT NULL,
+    ingested_timestamp  TIMESTAMPTZ DEFAULT now(),
+    payload             JSONB NOT NULL,
+    processed_at        TIMESTAMPTZ,
+    PRIMARY KEY (id, ingested_date)
+) PARTITION BY RANGE (ingested_date);
+
+CREATE TABLE IF NOT EXISTS raw.t212_history_cursor (
+    endpoint       TEXT PRIMARY KEY,
+    last_cursor    TEXT,
+    last_event_ts  TIMESTAMPTZ,
+    updated_at     TIMESTAMPTZ DEFAULT now()
+);
+"""
+
+_DROP_SQL = """
+DROP TABLE IF EXISTS raw.t212_history_cursor CASCADE;
+DROP TABLE IF EXISTS raw.t212_history_transaction CASCADE;
+DROP TABLE IF EXISTS raw.t212_history_order CASCADE;
+DROP TABLE IF EXISTS raw.t212_history_dividend CASCADE;
+"""
+
+
+@pytest.fixture(scope="module")
+def postgres_raw_history_schema():
+    if not DATABASE_URL or not DATABASE_URL.startswith("postgresql"):
+        pytest.skip("DATABASE_URL not configured for Postgres")
+
+    try:
+        engine = create_engine(DATABASE_URL)
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+    except Exception as e:
+        pytest.skip(f"Postgres not reachable: {e}")
+
+    with engine.begin() as conn:
+        for stmt in filter(None, (s.strip() for s in _CREATE_SQL.split(";"))):
+            conn.execute(text(stmt))
+
+    yield engine
+
+    with engine.begin() as conn:
+        for stmt in filter(None, (s.strip() for s in _DROP_SQL.split(";"))):
+            conn.execute(text(stmt))
+    engine.dispose()

--- a/tests/ingestion/integration/test_t212_history_raw_integration.py
+++ b/tests/ingestion/integration/test_t212_history_raw_integration.py
@@ -10,9 +10,8 @@ Skipped automatically if the DB isn't reachable.
 """
 
 from datetime import date
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
-import pytest
 from sqlalchemy import text
 
 

--- a/tests/ingestion/integration/test_t212_history_raw_integration.py
+++ b/tests/ingestion/integration/test_t212_history_raw_integration.py
@@ -1,0 +1,170 @@
+"""
+Integration test: T212 history bronze pipeline against a real Postgres.
+
+Stubs the T212 API client with canned JSON pages (no external HTTP) and
+verifies that rows and cursor state land in the expected raw tables,
+and that a second run with the same fixtures is idempotent.
+
+Requires Postgres reachable via DATABASE_URL (see docker-compose.yml).
+Skipped automatically if the DB isn't reachable.
+"""
+
+from datetime import date
+from unittest.mock import patch, MagicMock
+
+import pytest
+from sqlalchemy import text
+
+
+_DIVIDEND_PAGE = {
+    "items": [
+        {
+            "reference": "DIV-001",
+            "paidOn": "2026-04-19T12:00:00Z",
+            "amount": 1.23,
+            "ticker": "AAPL_US_EQ",
+            "type": "ORDINARY",
+        },
+        {
+            "reference": "DIV-002",
+            "paidOn": "2026-04-18T12:00:00Z",
+            "amount": 2.34,
+            "ticker": "MSFT_US_EQ",
+            "type": "ORDINARY",
+        },
+    ],
+    "nextPagePath": None,
+}
+
+_ORDER_PAGE = {
+    "items": [
+        {
+            "order": {
+                "id": 987654321,
+                "createdAt": "2026-04-19T09:00:00Z",
+                "ticker": "AAPL_US_EQ",
+                "status": "FILLED",
+            },
+            "fill": {"id": 111, "price": 150.0, "quantity": 1},
+        },
+    ],
+    "nextPagePath": None,
+}
+
+_TRANSACTION_PAGE = {
+    "items": [
+        {
+            "reference": "TXN-001",
+            "dateTime": "2026-04-19T10:00:00Z",
+            "amount": 100.0,
+            "currency": "GBP",
+            "type": "DEPOSIT",
+        },
+    ],
+    "nextPagePath": None,
+}
+
+
+def _fake_paginated_factory():
+    async def fake_paginated(endpoint, cursor=None, limit=50, stop_predicate=None):
+        if endpoint.endswith("history/dividends"):
+            yield _DIVIDEND_PAGE
+        elif endpoint.endswith("history/orders"):
+            yield _ORDER_PAGE
+        elif endpoint.endswith("history/transactions"):
+            yield _TRANSACTION_PAGE
+        else:
+            raise AssertionError(f"unexpected endpoint: {endpoint}")
+    return fake_paginated
+
+
+def _run_pipeline():
+    from pipelines.application.runners.pipeline_bronze_t212_history import (
+        PipelineT212History,
+    )
+    from pipelines.infrastructure.clients.api_client_trading212 import (
+        Trading212APIClient,
+    )
+
+    with patch.object(Trading212APIClient, "get_paginated", _fake_paginated_factory()):
+        PipelineT212History().run()
+
+
+def _table_counts(engine):
+    with engine.connect() as conn:
+        return {
+            "dividend": conn.execute(
+                text("SELECT count(*) FROM raw.t212_history_dividend")
+            ).scalar(),
+            "order": conn.execute(
+                text("SELECT count(*) FROM raw.t212_history_order")
+            ).scalar(),
+            "transaction": conn.execute(
+                text("SELECT count(*) FROM raw.t212_history_transaction")
+            ).scalar(),
+            "cursor": conn.execute(
+                text("SELECT count(*) FROM raw.t212_history_cursor")
+            ).scalar(),
+        }
+
+
+def test_full_pipeline_writes_rows_and_cursor_and_is_idempotent(
+    postgres_raw_history_schema,
+):
+    engine = postgres_raw_history_schema
+
+    # Run 1 — expect all rows and cursor state to land.
+    _run_pipeline()
+
+    counts = _table_counts(engine)
+    assert counts == {"dividend": 2, "order": 1, "transaction": 1, "cursor": 3}
+
+    with engine.connect() as conn:
+        # Partition for today must exist for at least the dividend parent.
+        today_partition = f"raw.t212_history_dividend_{date.today().strftime('%Y_%m_%d')}"
+        exists = conn.execute(
+            text(
+                "SELECT to_regclass(:name) IS NOT NULL AS exists"
+            ),
+            {"name": today_partition},
+        ).scalar()
+        assert exists is True
+
+        # JSONB round-trip preserves payload.
+        payload = conn.execute(
+            text(
+                "SELECT payload FROM raw.t212_history_dividend WHERE id = 'DIV-001'"
+            )
+        ).scalar()
+        assert payload["ticker"] == "AAPL_US_EQ"
+        assert payload["type"] == "ORDINARY"
+
+        # Cursor populated with newest event timestamp per endpoint.
+        cursor_rows = {
+            row.endpoint: row
+            for row in conn.execute(
+                text(
+                    "SELECT endpoint, last_cursor, last_event_ts "
+                    "FROM raw.t212_history_cursor"
+                )
+            )
+        }
+        assert set(cursor_rows) == {"dividends", "orders", "transactions"}
+        assert cursor_rows["dividends"].last_event_ts is not None
+
+    # Run 2 — same fixtures. ON CONFLICT DO NOTHING keeps counts flat.
+    cursor_before = cursor_rows["dividends"].last_event_ts
+
+    _run_pipeline()
+
+    counts_after = _table_counts(engine)
+    assert counts_after == counts, "second run must be idempotent"
+
+    with engine.connect() as conn:
+        cursor_after = conn.execute(
+            text(
+                "SELECT last_event_ts FROM raw.t212_history_cursor "
+                "WHERE endpoint = 'dividends'"
+            )
+        ).scalar()
+    assert cursor_after == cursor_before, "cursor must not regress on re-run"

--- a/tests/ingestion/test_pipeline_bronze_t212_history.py
+++ b/tests/ingestion/test_pipeline_bronze_t212_history.py
@@ -13,10 +13,8 @@ All DB and API interactions are mocked (unittest.mock), matching the
 repo's existing test style (see tests/ingestion/test_pipeline_bugs.py).
 """
 
-from datetime import datetime, timezone
+from datetime import datetime
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ingestion/test_pipeline_bronze_t212_history.py
+++ b/tests/ingestion/test_pipeline_bronze_t212_history.py
@@ -1,0 +1,299 @@
+"""
+Unit tests for the T212 historical-events bronze pipeline.
+
+Covers:
+  - Source paginates until nextPagePath is null
+  - Source stops when stored high-water mark is reached
+  - One endpoint failing does not prevent the others from being extracted
+  - Loader inserts per-endpoint with ON CONFLICT and upserts cursor state
+  - Loader persists the newest event timestamp as high-water mark
+  - Pipeline wires source → destination
+
+All DB and API interactions are mocked (unittest.mock), matching the
+repo's existing test style (see tests/ingestion/test_pipeline_bugs.py).
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _ts(s: str) -> datetime:
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+def _page(items, next_path=None):
+    return {"items": items, "nextPagePath": next_path}
+
+
+def _async_gen(pages):
+    async def _gen(*_args, **_kwargs):
+        for page in pages:
+            yield page
+    return _gen
+
+
+# ---------------------------------------------------------------------------
+# Source
+# ---------------------------------------------------------------------------
+
+
+class TestSourcePagination:
+
+    def _build_source(self, paginated_factory, stored_ts=None):
+        from pipelines.application.runners.pipeline_bronze_t212_history import (
+            Trading212HistorySource,
+        )
+
+        with patch.object(Trading212HistorySource, "__init__", lambda self: None):
+            source = Trading212HistorySource()
+        source._api_client = MagicMock()
+        source._api_client.get_paginated = paginated_factory
+        source._db_client = MagicMock()
+        source._get_stored_high_water_mark = MagicMock(return_value=stored_ts)
+        return source
+
+    def test_follows_next_page_path_until_null(self):
+        pages_by_endpoint = {
+            "equity/history/dividends": [
+                _page(
+                    [{"reference": "d1", "paidOn": "2026-04-19T12:00:00Z"}],
+                    next_path="/api/v0/equity/history/dividends?cursor=111",
+                ),
+                _page(
+                    [{"reference": "d2", "paidOn": "2026-04-18T12:00:00Z"}],
+                    next_path=None,
+                ),
+            ],
+            "equity/history/orders": [
+                _page(
+                    [{"order": {"id": 1, "createdAt": "2026-04-19T09:00:00Z"}}],
+                    next_path=None,
+                ),
+            ],
+            "equity/history/transactions": [
+                _page(
+                    [{"reference": "t1", "dateTime": "2026-04-19T10:00:00Z"}],
+                    next_path=None,
+                ),
+            ],
+        }
+
+        async def fake_paginated(endpoint, cursor=None, limit=50, stop_predicate=None):
+            for page in pages_by_endpoint[endpoint]:
+                yield page
+
+        source = self._build_source(fake_paginated, stored_ts=None)
+        result = source.extract()
+
+        assert len(result["dividends"]) == 2
+        assert [d["reference"] for d in result["dividends"]] == ["d1", "d2"]
+        assert len(result["orders"]) == 1
+        assert len(result["transactions"]) == 1
+        assert result["cursors"]["dividends"]["last_event_ts"] == _ts("2026-04-19T12:00:00Z")
+
+    def test_stops_at_stored_cursor(self):
+        stored = _ts("2026-04-18T00:00:00Z")
+
+        dividend_pages = [
+            _page(
+                [
+                    {"reference": "d_new", "paidOn": "2026-04-19T12:00:00Z"},
+                    {"reference": "d_old", "paidOn": "2026-04-17T12:00:00Z"},
+                ],
+                next_path="/api/v0/equity/history/dividends?cursor=next",
+            ),
+        ]
+        other_pages = {
+            "equity/history/orders": [],
+            "equity/history/transactions": [],
+        }
+
+        async def fake_paginated(endpoint, cursor=None, limit=50, stop_predicate=None):
+            if endpoint == "equity/history/dividends":
+                for page in dividend_pages:
+                    yield page
+                    if stop_predicate and stop_predicate(page):
+                        return
+            else:
+                for page in other_pages[endpoint]:
+                    yield page
+
+        source = self._build_source(fake_paginated, stored_ts=stored)
+        result = source.extract()
+
+        # The older item (2026-04-17) must be filtered out; only the new one kept.
+        assert [d["reference"] for d in result["dividends"]] == ["d_new"]
+        assert result["cursors"]["dividends"]["last_event_ts"] == _ts("2026-04-19T12:00:00Z")
+
+    def test_isolates_endpoint_failures(self):
+        async def failing_divs(endpoint, cursor=None, limit=50, stop_predicate=None):
+            if endpoint == "equity/history/dividends":
+                raise RuntimeError("boom")
+            if endpoint == "equity/history/orders":
+                yield _page(
+                    [{"order": {"id": 42, "createdAt": "2026-04-19T09:00:00Z"}}],
+                    next_path=None,
+                )
+            else:
+                yield _page(
+                    [{"reference": "t1", "dateTime": "2026-04-19T10:00:00Z"}],
+                    next_path=None,
+                )
+
+        source = self._build_source(failing_divs, stored_ts=None)
+        result = source.extract()
+
+        assert result["dividends"] == []
+        assert len(result["orders"]) == 1
+        assert len(result["transactions"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+class TestLoader:
+
+    def _build_loader(self):
+        from pipelines.application.runners.loaders.loader_bronze_t212_history import (
+            FullLoaderPostgresT212History,
+        )
+
+        with patch(
+            "pipelines.application.runners.loaders.loader_bronze_t212_history.SQLModelClient"
+        ) as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+            loader = FullLoaderPostgresT212History()
+        return loader, mock_client
+
+    def test_inserts_per_table_with_on_conflict(self):
+        loader, mock_client = self._build_loader()
+        data = {
+            "dividends": [
+                {"reference": "d1", "paidOn": "2026-04-19T12:00:00Z", "amount": 1.23},
+            ],
+            "orders": [
+                {"order": {"id": 42, "createdAt": "2026-04-19T09:00:00Z"}},
+            ],
+            "transactions": [
+                {"reference": "t1", "dateTime": "2026-04-19T10:00:00Z"},
+            ],
+            "cursors": {},
+        }
+
+        loader._loader(data)
+
+        # One execute per endpoint insert. Cursor execs skipped (cursors empty).
+        executed_sqls = [call.args[0] for call in mock_client.execute.call_args_list]
+        assert any("raw.t212_history_dividend" in s for s in executed_sqls)
+        assert any("raw.t212_history_order" in s for s in executed_sqls)
+        assert any("raw.t212_history_transaction" in s for s in executed_sqls)
+        assert all("ON CONFLICT (id, ingested_date) DO NOTHING" in s
+                   for s in executed_sqls if s.strip().startswith("INSERT INTO raw.t212_history_"))
+
+    def test_upserts_cursor_with_newest_event(self):
+        loader, mock_client = self._build_loader()
+        newest = _ts("2026-04-19T12:00:00Z")
+        data = {
+            "dividends": [],
+            "orders": [],
+            "transactions": [],
+            "cursors": {
+                "dividends": {"last_cursor": "abc", "last_event_ts": newest},
+            },
+        }
+
+        loader._loader(data)
+
+        cursor_calls = [
+            call for call in mock_client.execute.call_args_list
+            if "raw.t212_history_cursor" in call.args[0]
+        ]
+        assert len(cursor_calls) == 1
+        params = cursor_calls[0].kwargs["params"]
+        assert params["endpoint"] == "dividends"
+        assert params["last_cursor"] == "abc"
+        assert params["last_event_ts"] == newest
+
+    def test_skips_items_without_id(self):
+        loader, mock_client = self._build_loader()
+        data = {
+            "dividends": [
+                {"paidOn": "2026-04-19T12:00:00Z"},  # no reference
+                {"reference": "d_ok", "paidOn": "2026-04-19T13:00:00Z"},
+            ],
+            "orders": [],
+            "transactions": [],
+            "cursors": {},
+        }
+
+        loader._loader(data)
+
+        dividend_inserts = [
+            call for call in mock_client.execute.call_args_list
+            if "raw.t212_history_dividend" in call.args[0]
+        ]
+        assert len(dividend_inserts) == 1
+        assert dividend_inserts[0].kwargs["params"]["id"] == "d_ok"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline wiring
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineWiring:
+
+    def test_run_wires_source_to_destination(self):
+        from pipelines.application.runners.pipeline_bronze_t212_history import (
+            PipelineT212History,
+        )
+
+        extracted = {
+            "dividends": [{"reference": "d1", "paidOn": "2026-04-19T12:00:00Z"}],
+            "orders": [],
+            "transactions": [],
+            "cursors": {},
+        }
+
+        with patch.object(PipelineT212History, "__init__", lambda self: None):
+            pipeline = PipelineT212History()
+        pipeline._source = MagicMock()
+        pipeline._source.extract.return_value = extracted
+        pipeline._destination = MagicMock()
+
+        pipeline.run()
+
+        pipeline._source.extract.assert_called_once()
+        pipeline._destination.load.assert_called_once_with(extracted)
+
+    def test_run_skips_load_when_no_events(self):
+        from pipelines.application.runners.pipeline_bronze_t212_history import (
+            PipelineT212History,
+        )
+
+        with patch.object(PipelineT212History, "__init__", lambda self: None):
+            pipeline = PipelineT212History()
+        pipeline._source = MagicMock()
+        pipeline._source.extract.return_value = {
+            "dividends": [],
+            "orders": [],
+            "transactions": [],
+            "cursors": {},
+        }
+        pipeline._destination = MagicMock()
+
+        pipeline.run()
+
+        pipeline._destination.load.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds a new bronze pipeline that ingests three Trading212 historical-event endpoints into the raw layer, completing the missing event-stream side of the bronze ingestion that the snapshot pipeline (`t212_bronze`) does not cover.
- Per-endpoint cursor/high-water-mark state is persisted in `raw.t212_history_cursor` so steady-state hourly runs pull only new events (cheap under the 6 req/min limit). First run pulls full history.
- Idempotency via `ON CONFLICT (id, ingested_date) DO NOTHING` — safe to re-run and safe across backfill/overlap windows.

## What changed

| Area | Change |
|---|---|
| **Migration** | `005_raw_t212_history.py` — three partitioned event tables (`raw.t212_history_dividend`, `raw.t212_history_order`, `raw.t212_history_transaction`) + cursor state table (`raw.t212_history_cursor`) |
| **Client** | `Trading212APIClient.get_paginated` — async generator following `nextPagePath` with 429 / rate-limit backoff. Concrete class only; interface unchanged. |
| **Loader** | `FullLoaderPostgresT212History` — subclasses `FullLoader`, creates today's partitions on all three tables, inserts rows with `ON CONFLICT DO NOTHING`, upserts cursor after each endpoint |
| **Pipeline** | `PipelineT212History` — Source reads stored high-water mark, pages backward until exhausted or mark reached; each endpoint isolated in try/except so one failure doesn't stop others |
| **Orchestration** | `flow_t212_history_bronze.py` + `prefect.yaml` deployment (hourly, same work pool as existing flows) |
| **Factory** | `t212_history_bronze` registered in `PipelineFactory` |
| **SQL templates** | `t212_history_insert.sql`, `t212_history_cursor_upsert.sql`, `t212_history_cursor_select.sql` |
| **Tests** | 6 unit tests + 1 integration test (skipped if Postgres unreachable) |

## Reviewer notes

- **CSV export flow is deferred** — the async `POST /history/exports` + poll pattern is a separate concern and belongs in its own branch.
- **Silver/gold untouched** — this PR is raw layer only. No downstream pipelines consume the new tables yet.
- **First-run backfill** — at 6 req/min across three endpoints, a full history pull will be slow. Recommend running manually off-hours before enabling the schedule. The CSV export branch is the long-term solution for large backfills.
- **Transaction cursor is `TEXT`** — T212 transactions cursor is a string while the other two are int64. The `raw.t212_history_cursor.last_cursor` column is `TEXT` to handle both without type coercion.
- The integration test requires `docker-compose up -d postgres` and `DATABASE_URL` to be set; it is skipped automatically in CI if the DB is not reachable.

## Test plan

- [ ] `pytest tests/ingestion/test_pipeline_bronze_t212_history.py -v` — all 6 unit tests pass
- [ ] `docker-compose up -d postgres && pytest tests/ingestion/integration/ -v` — integration test passes
- [ ] `alembic upgrade head` — migration 005 applies cleanly
- [ ] `alembic downgrade -1` — downgrade drops all four tables cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)