### PR TITLE
fix(pipeline): replace async pagination with sync iter_paginated to fix Prefect crash

### DIFF
--- a/src/pipelines/application/runners/pipeline_bronze_t212_history.py
+++ b/src/pipelines/application/runners/pipeline_bronze_t212_history.py
@@ -13,7 +13,6 @@ event timestamp, so steady-state runs are cheap under the 6 req/min limit.
 
 import os
 import logging
-import asyncio
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -96,9 +95,7 @@ class Trading212HistorySource(Source):
         for endpoint_key, path in _ENDPOINTS.items():
             try:
                 stored_ts = self._get_stored_high_water_mark(endpoint_key)
-                items, newest_ts, newest_cursor = asyncio.run(
-                    self._pull_endpoint(endpoint_key, path, stored_ts)
-                )
+                items, newest_ts, newest_cursor = self._pull_endpoint(endpoint_key, path, stored_ts)
                 result[endpoint_key] = items
                 result["cursors"][endpoint_key] = {
                     "last_cursor": newest_cursor,
@@ -116,7 +113,7 @@ class Trading212HistorySource(Source):
 
         return result
 
-    async def _pull_endpoint(self, endpoint_key: str, path: str, stored_ts):
+    def _pull_endpoint(self, endpoint_key: str, path: str, stored_ts):
         """Page through endpoint, collecting items newer than stored_ts."""
         collected: list[dict] = []
         newest_ts = None
@@ -136,7 +133,7 @@ class Trading212HistorySource(Source):
                 return False
             return oldest <= stored_ts
 
-        async for page in self._api_client.get_paginated(
+        for page in self._api_client.iter_paginated(
             endpoint=path,
             stop_predicate=stop_once_page_is_older,
         ):

--- a/src/pipelines/infrastructure/clients/api_client_trading212.py
+++ b/src/pipelines/infrastructure/clients/api_client_trading212.py
@@ -4,7 +4,7 @@ import time
 import httpx
 import base64
 import logging
-from typing import AsyncIterator, Callable, Optional
+from typing import Callable, Iterator, Optional
 from urllib.parse import urljoin
 
 from ...application.interfaces.interface_api_client import APIClient
@@ -50,20 +50,20 @@ class Trading212APIClient(APIClient):
                 )
                 return {"error": response.status_code, "message": "API call failed"}
 
-    async def get_paginated(
+    def iter_paginated(
         self,
         endpoint: str,
         cursor: Optional[str] = None,
         limit: int = 50,
         stop_predicate: Optional[Callable[[dict], bool]] = None,
-    ) -> AsyncIterator[dict]:
+    ) -> Iterator[dict]:
         """
-        Iterate T212 cursor-paginated endpoints following nextPagePath until
-        exhausted or stop_predicate(page) returns True.
+        Synchronous page iterator for T212 cursor-paginated endpoints.
 
-        On HTTP 429, reads x-ratelimit-reset and sleeps until reset.
-        On other non-200, raises httpx.HTTPStatusError rather than returning
-        an error-dict, so callers can safely loop on successful pages only.
+        Follows nextPagePath until exhausted or stop_predicate(page) returns True.
+        On HTTP 429, reads x-ratelimit-reset and sleeps with time.sleep (safe in
+        Prefect sync tasks — no async event loop interference).
+        On other non-200, raises httpx.HTTPStatusError.
         """
         header = {"Authorization": f"Basic {self.credentials()}"}
 
@@ -71,17 +71,17 @@ class Trading212APIClient(APIClient):
         if cursor is not None:
             next_path = f"{next_path}&cursor={cursor}"
 
-        async with httpx.AsyncClient() as client:
+        with httpx.Client() as client:
             while next_path:
                 url = urljoin(self.url, next_path)
                 logging.info(f"Paginated API call to {url}")
-                response = await client.get(url, headers=header)
+                response = client.get(url, headers=header)
 
                 if response.status_code == 429:
                     reset = response.headers.get("x-ratelimit-reset")
                     wait_s = max(int(reset) - int(time.time()), 1) if reset else 5
                     logging.warning(f"Rate limited; sleeping {wait_s}s")
-                    await asyncio.sleep(wait_s)
+                    time.sleep(wait_s)
                     continue
 
                 response.raise_for_status()

--- a/src/pipelines/infrastructure/clients/api_client_trading212.py
+++ b/src/pipelines/infrastructure/clients/api_client_trading212.py
@@ -1,5 +1,4 @@
 import os
-import asyncio
 import time
 import httpx
 import base64

--- a/tests/ingestion/integration/test_t212_history_raw_integration.py
+++ b/tests/ingestion/integration/test_t212_history_raw_integration.py
@@ -65,7 +65,7 @@ _TRANSACTION_PAGE = {
 
 
 def _fake_paginated_factory():
-    async def fake_paginated(endpoint, cursor=None, limit=50, stop_predicate=None):
+    def fake_paginated(endpoint, cursor=None, limit=50, stop_predicate=None):
         if endpoint.endswith("history/dividends"):
             yield _DIVIDEND_PAGE
         elif endpoint.endswith("history/orders"):
@@ -85,7 +85,7 @@ def _run_pipeline():
         Trading212APIClient,
     )
 
-    with patch.object(Trading212APIClient, "get_paginated", _fake_paginated_factory()):
+    with patch.object(Trading212APIClient, "iter_paginated", _fake_paginated_factory()):
         PipelineT212History().run()
 
 

--- a/tests/ingestion/test_pipeline_bronze_t212_history.py
+++ b/tests/ingestion/test_pipeline_bronze_t212_history.py
@@ -52,7 +52,7 @@ class TestSourcePagination:
         with patch.object(Trading212HistorySource, "__init__", lambda self: None):
             source = Trading212HistorySource()
         source._api_client = MagicMock()
-        source._api_client.get_paginated = paginated_factory
+        source._api_client.iter_paginated = paginated_factory
         source._db_client = MagicMock()
         source._get_stored_high_water_mark = MagicMock(return_value=stored_ts)
         return source
@@ -83,7 +83,7 @@ class TestSourcePagination:
             ],
         }
 
-        async def fake_paginated(endpoint, cursor=None, limit=50, stop_predicate=None):
+        def fake_paginated(endpoint, cursor=None, limit=50, stop_predicate=None):
             for page in pages_by_endpoint[endpoint]:
                 yield page
 
@@ -113,7 +113,7 @@ class TestSourcePagination:
             "equity/history/transactions": [],
         }
 
-        async def fake_paginated(endpoint, cursor=None, limit=50, stop_predicate=None):
+        def fake_paginated(endpoint, cursor=None, limit=50, stop_predicate=None):
             if endpoint == "equity/history/dividends":
                 for page in dividend_pages:
                     yield page
@@ -131,7 +131,7 @@ class TestSourcePagination:
         assert result["cursors"]["dividends"]["last_event_ts"] == _ts("2026-04-19T12:00:00Z")
 
     def test_isolates_endpoint_failures(self):
-        async def failing_divs(endpoint, cursor=None, limit=50, stop_predicate=None):
+        def failing_divs(endpoint, cursor=None, limit=50, stop_predicate=None):
             if endpoint == "equity/history/dividends":
                 raise RuntimeError("boom")
             if endpoint == "equity/history/orders":


### PR DESCRIPTION
## Summary

- Replaces `async get_paginated` on `Trading212APIClient` with sync `iter_paginated` using `httpx.Client` + `time.sleep`
- Removes `asyncio` dependency from `Trading212HistorySource._pull_endpoint` — now a plain sync method
- Updates all unit and integration test fakes from async generators to sync generators

## Root cause

Prefect sync tasks run in a thread pool. The prior implementation used `asyncio.run()` inside a Prefect task to drive the async paginator. When Prefect sends an interrupt signal, `asyncio` cancels the inner `await asyncio.sleep()` (used for 429 rate-limit backoff), which `asyncio.run()` converts to `KeyboardInterrupt` — crashing the flow and losing in-progress pagination state.

## Test plan

- [x] All 8 unit tests pass: `PYTHONPATH=src pytest tests/ingestion/test_pipeline_bronze_t212_history.py`
- [ ] Integration test passes with docker-compose Postgres
- [ ] Manual smoke: run pipeline, confirm rows land in all three raw tables after API key is updated with history scopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)